### PR TITLE
feat(ui-radio): add a modern, accessible radio button component with support for labels, helper text, and error states

### DIFF
--- a/internal/storybook/.storybook/main.ts
+++ b/internal/storybook/.storybook/main.ts
@@ -29,6 +29,7 @@ const config: StorybookConfig = {
     getStoriesPath('interfaces/ui-text-area'),
     getStoriesPath('interfaces/ui-breadcrumb'),
     getStoriesPath('interfaces/ui-switch'),
+    getStoriesPath('interfaces/ui-radio'),
   ],
   addons: [
     getAbsolutePath('@storybook/addon-essentials'),

--- a/packages/interfaces/module/package.json
+++ b/packages/interfaces/module/package.json
@@ -39,6 +39,7 @@
     "@react-beauty/ui-icon": "workspace:*",
     "@react-beauty/ui-menu-item": "workspace:*",
     "@react-beauty/ui-pagination": "workspace:*",
+    "@react-beauty/ui-radio": "workspace:*",
     "@react-beauty/ui-switch": "workspace:*",
     "@react-beauty/ui-tag": "workspace:*",
     "@react-beauty/ui-text-area": "workspace:*",

--- a/packages/interfaces/module/src/index.ts
+++ b/packages/interfaces/module/src/index.ts
@@ -15,3 +15,4 @@ export * from '@react-beauty/ui-tooltip';
 export * from '@react-beauty/ui-text-input';
 export * from '@react-beauty/ui-text-area';
 export * from '@react-beauty/ui-switch';
+export * from '@react-beauty/ui-radio';

--- a/packages/interfaces/ui-core/src/dark/index.css
+++ b/packages/interfaces/ui-core/src/dark/index.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 01 May 2025 03:40:11 GMT
+ * Generated on Thu, 01 May 2025 06:23:07 GMT
  */
 
 :root[data-theme='dark'] {
@@ -124,6 +124,9 @@
   --components-pagination-disabled-opacity-container: 0.5;
   --components-pagination-disabled-opacity-item: 0.5;
   --components-pagination-disabled-opacity-nav-item: 0.3;
+  --components-radio-size: 20px;
+  --components-radio-transition-duration: 0.2s;
+  --components-radio-transition-timing: ease-in-out;
   --components-switch-width: 40px;
   --components-switch-height: 24px;
   --components-switch-thumb-size: 18px;
@@ -290,6 +293,25 @@
   --components-pagination-colors-active-background: var(--colors-main-picollo);
   --components-pagination-colors-active-text: var(--colors-main-goten);
   --components-pagination-colors-focus-outline: var(--colors-supportive-whis-60);
+  --components-radio-border-radius: var(--border-radius-rounded);
+  --components-radio-font-size-label: var(--font-size-sm);
+  --components-radio-font-size-helper: var(--font-size-xs);
+  --components-radio-line-height-label: var(--font-line-height-sm);
+  --components-radio-line-height-helper: var(--font-line-height-xs);
+  --components-radio-font-weight-label: var(--font-weight-medium);
+  --components-radio-gap: var(--space-1);
+  --components-radio-group-gap: var(--space-2);
+  --components-radio-colors-label: var(--colors-main-bulma);
+  --components-radio-colors-border-unchecked: var(--colors-main-trunks);
+  --components-radio-colors-border-checked: var(--colors-main-picollo);
+  --components-radio-colors-border-disabled: var(--colors-main-beerus);
+  --components-radio-colors-background-unchecked: var(--colors-main-gohan);
+  --components-radio-colors-background-checked: var(--colors-main-gohan);
+  --components-radio-colors-background-disabled: var(--colors-main-gohan);
+  --components-radio-colors-dot: var(--colors-main-picollo);
+  --components-radio-colors-focus-ring: var(--colors-supportive-whis-60);
+  --components-radio-colors-helper-text-normal: var(--colors-main-trunks);
+  --components-radio-colors-helper-text-error: var(--colors-supportive-chichi);
   --components-switch-border-radius: var(--border-radius-rounded);
   --components-switch-font-size-label: var(--font-size-sm);
   --components-switch-font-size-helper: var(--font-size-xs);

--- a/packages/interfaces/ui-core/src/light/index.css
+++ b/packages/interfaces/ui-core/src/light/index.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 01 May 2025 03:40:11 GMT
+ * Generated on Thu, 01 May 2025 06:23:07 GMT
  */
 
 :root[data-theme='light'] {
@@ -124,6 +124,9 @@
   --components-pagination-disabled-opacity-container: 0.5;
   --components-pagination-disabled-opacity-item: 0.5;
   --components-pagination-disabled-opacity-nav-item: 0.3;
+  --components-radio-size: 20px;
+  --components-radio-transition-duration: 0.2s;
+  --components-radio-transition-timing: ease-in-out;
   --components-switch-width: 40px;
   --components-switch-height: 24px;
   --components-switch-thumb-size: 18px;
@@ -290,6 +293,25 @@
   --components-pagination-colors-active-background: var(--colors-main-picollo);
   --components-pagination-colors-active-text: var(--colors-main-goten);
   --components-pagination-colors-focus-outline: var(--colors-supportive-whis-60);
+  --components-radio-border-radius: var(--border-radius-rounded);
+  --components-radio-font-size-label: var(--font-size-sm);
+  --components-radio-font-size-helper: var(--font-size-xs);
+  --components-radio-line-height-label: var(--font-line-height-sm);
+  --components-radio-line-height-helper: var(--font-line-height-xs);
+  --components-radio-font-weight-label: var(--font-weight-medium);
+  --components-radio-gap: var(--space-1);
+  --components-radio-group-gap: var(--space-2);
+  --components-radio-colors-label: var(--colors-main-bulma);
+  --components-radio-colors-border-unchecked: var(--colors-main-trunks);
+  --components-radio-colors-border-checked: var(--colors-main-picollo);
+  --components-radio-colors-border-disabled: var(--colors-main-beerus);
+  --components-radio-colors-background-unchecked: var(--colors-main-gohan);
+  --components-radio-colors-background-checked: var(--colors-main-gohan);
+  --components-radio-colors-background-disabled: var(--colors-main-gohan);
+  --components-radio-colors-dot: var(--colors-main-picollo);
+  --components-radio-colors-focus-ring: var(--colors-supportive-whis-60);
+  --components-radio-colors-helper-text-normal: var(--colors-main-trunks);
+  --components-radio-colors-helper-text-error: var(--colors-supportive-chichi);
   --components-switch-border-radius: var(--border-radius-rounded);
   --components-switch-font-size-label: var(--font-size-sm);
   --components-switch-font-size-helper: var(--font-size-xs);

--- a/packages/interfaces/ui-radio/README.md
+++ b/packages/interfaces/ui-radio/README.md
@@ -1,0 +1,184 @@
+# Radio Component
+
+A modern, accessible radio button component for React applications with support for labels, helper text, and error states.
+
+## Installation
+
+```bash
+npm install @react-beauty/ui-radio
+```
+
+## Usage
+
+```jsx
+import { RadioGroup, RadioInput } from '@react-beauty/ui-radio';
+import { useState } from 'react';
+
+// Basic Usage
+function BasicRadio() {
+  const [value, setValue] = useState('');
+  
+  return (
+    <RadioGroup name="basic-radio" selectedValue={value} onValueChange={setValue}>
+      <RadioInput value="option1">
+        <RadioInput.Field />
+        <RadioInput.Label>Option 1</RadioInput.Label>
+      </RadioInput>
+    </RadioGroup>
+  );
+}
+
+// With Helper Text
+function RadioWithHelper() {
+  const [value, setValue] = useState('');
+  
+  return (
+    <RadioGroup name="helper-radio" selectedValue={value} onValueChange={setValue}>
+      <RadioInput value="option1">
+        <RadioInput.Field />
+        <RadioInput.Label>Option 1</RadioInput.Label>
+        <RadioInput.HelperText>This is a helper text</RadioInput.HelperText>
+      </RadioInput>
+    </RadioGroup>
+  );
+}
+
+// With Error State
+function RadioWithError() {
+  const [value, setValue] = useState('');
+  
+  return (
+    <RadioGroup name="error-radio" selectedValue={value} onValueChange={setValue} hasError>
+      <RadioInput value="option1">
+        <RadioInput.Field />
+        <RadioInput.Label>Option 1</RadioInput.Label>
+        <RadioInput.HelperText>This option has an error</RadioInput.HelperText>
+      </RadioInput>
+    </RadioGroup>
+  );
+}
+
+// Disabled Radio
+function DisabledRadio() {
+  const [value, setValue] = useState('option1');
+  
+  return (
+    <RadioGroup name="disabled-radio" selectedValue={value} onValueChange={setValue} isDisabled>
+      <RadioInput value="option1">
+        <RadioInput.Field />
+        <RadioInput.Label>Option 1</RadioInput.Label>
+        <RadioInput.HelperText>This option is disabled</RadioInput.HelperText>
+      </RadioInput>
+    </RadioGroup>
+  );
+}
+
+// Radio Group with Multiple Options
+function RadioGroupExample() {
+  const [selectedValue, setSelectedValue] = useState('option1');
+  
+  return (
+    <RadioGroup 
+      name="radio-group" 
+      selectedValue={selectedValue} 
+      onValueChange={setSelectedValue}
+    >
+      <RadioInput value="option1">
+        <RadioInput.Field />
+        <RadioInput.Label>Option 1</RadioInput.Label>
+      </RadioInput>
+      <RadioInput value="option2">
+        <RadioInput.Field />
+        <RadioInput.Label>Option 2</RadioInput.Label>
+      </RadioInput>
+      <RadioInput value="option3">
+        <RadioInput.Field />
+        <RadioInput.Label>Option 3</RadioInput.Label>
+      </RadioInput>
+    </RadioGroup>
+  );
+}
+
+// Interactive Radio Group with Validation
+function InteractiveRadioGroup() {
+  const [selectedValue, setSelectedValue] = useState('');
+  const [error, setError] = useState(true);
+
+  const handleChange = (value) => {
+    setSelectedValue(value);
+    setError(false);
+  };
+
+  return (
+    <>
+      <RadioGroup 
+        name="interactive-radio-group" 
+        selectedValue={selectedValue} 
+        onValueChange={handleChange}
+        hasError={error}
+      >
+        <RadioInput value="option1">
+          <RadioInput.Field />
+          <RadioInput.Label>Small</RadioInput.Label>
+        </RadioInput>
+        <RadioInput value="option2">
+          <RadioInput.Field />
+          <RadioInput.Label>Medium</RadioInput.Label>
+        </RadioInput>
+        <RadioInput value="option3">
+          <RadioInput.Field />
+          <RadioInput.Label>Large</RadioInput.Label>
+        </RadioInput>
+      </RadioGroup>
+      {error && (
+        <div style={{ color: 'red', marginTop: '8px' }}>
+          Please select a size
+        </div>
+      )}
+    </>
+  );
+}
+```
+
+## Components
+
+### RadioGroup
+
+The container component for a group of radio inputs. Props include:
+- `name`: string - The name for all radio buttons in the group (required)
+- `selectedValue`: string - The currently selected value
+- `onValueChange`: (value: string) => void - Callback when selection changes (required)
+- `isDisabled`: boolean - Disables all radio buttons in the group
+- `hasError`: boolean - Indicates if the radio group has an error
+
+### RadioInput
+
+Container for an individual radio input. Props include:
+- `value`: string - The value of the radio input (required)
+- `hasError`: boolean - Indicates if the radio has an error
+- `isDisabled`: boolean - Disables this specific radio input
+
+### RadioInput.Field
+
+The actual radio input element.
+
+### RadioInput.Label
+
+The label component for the radio input.
+
+### RadioInput.HelperText
+
+Text displayed below the radio to provide additional context or error messages.
+
+## Accessibility
+
+The radio component is built with accessibility in mind:
+- Properly associated labels and inputs
+- ARIA attributes for error and disabled states
+- Clear visual indicators for focus states
+- Proper contrast for all states
+- Keyboard navigation support
+
+## Customization
+
+Styling is handled through CSS variables, allowing for easy customization through the design token system.

--- a/packages/interfaces/ui-radio/eslint.config.js
+++ b/packages/interfaces/ui-radio/eslint.config.js
@@ -1,0 +1,3 @@
+import { configs } from "@react-beauty/eslint";
+
+export default configs;

--- a/packages/interfaces/ui-radio/package.json
+++ b/packages/interfaces/ui-radio/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@react-beauty/ui-radio",
+  "description": "ui-radio",
+  "license": "MIT",
+  "version": "1.0.0",
+  "stableVersion": "1.0.0",
+  "keywords": [
+    "react",
+    "@react-beauty",
+    "ui-radio"
+  ],
+  "author": "Your Name <your.email@example.com>",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "type": "./dist/index.d.ts"
+  },
+  "scripts": {
+    "lint": "eslint src",
+    "check": "tsc --noEmit",
+    "build": "vite build --configLoader runner",
+    "test": "vitest run --configLoader runner"
+  },
+  "dependencies": {
+    "@linaria/core": "6.3.0",
+    "@linaria/react": "6.3.0"
+  },
+  "peerDependencies": {
+    "@types/react": "^18.0",
+    "react": "^18.0"
+  },
+  "devDependencies": {
+    "@react-beauty/eslint": "workspace:*",
+    "@react-beauty/storybook": "workspace:*",
+    "@react-beauty/tsc": "workspace:*",
+    "@react-beauty/vite": "workspace:*",
+    "@react-beauty/vitest": "workspace:*"
+  }
+}

--- a/packages/interfaces/ui-radio/src/__tests__/radio.test.tsx
+++ b/packages/interfaces/ui-radio/src/__tests__/radio.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, fireEvent } from '@react-beauty/vitest/selector';
+import { vi } from 'vitest';
+
+import { RadioGroup, RadioInput } from '..';
+
+describe('Radio', () => {
+  it('renders correctly with all its parts', () => {
+    render(
+      <RadioGroup
+        name="test-radio"
+        selectedValue="test-value"
+        onValueChange={() => {}}
+      >
+        <RadioInput value="test-value">
+          <RadioInput.Field />
+          <RadioInput.Label>Test Label</RadioInput.Label>
+          <RadioInput.HelperText>Helper text</RadioInput.HelperText>
+        </RadioInput>
+      </RadioGroup>,
+    );
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+    expect(screen.getByText('Helper text')).toBeInTheDocument();
+    expect(screen.getByRole('radio')).toBeInTheDocument();
+  });
+
+  it('applies error state correctly to all child components', () => {
+    render(
+      <RadioGroup
+        name="test-radio"
+        selectedValue="test-value"
+        onValueChange={() => {}}
+        hasError
+      >
+        <RadioInput value="test-value">
+          <RadioInput.Field data-testid="radio-input" />
+          <RadioInput.Label>Error Label</RadioInput.Label>
+          <RadioInput.HelperText data-testid="helper-text">
+            Error message
+          </RadioInput.HelperText>
+        </RadioInput>
+      </RadioGroup>,
+    );
+
+    const helperText = screen.getByTestId('helper-text');
+    expect(helperText).toHaveAttribute('data-error', 'true');
+  });
+
+  it('handles radio changes correctly', () => {
+    const handleChange = vi.fn();
+    render(
+      <RadioGroup
+        name="test-radio"
+        selectedValue=""
+        onValueChange={handleChange}
+      >
+        <RadioInput value="test-value">
+          <RadioInput.Field data-testid="radio-input" />
+          <RadioInput.Label>Test Label</RadioInput.Label>
+        </RadioInput>
+      </RadioGroup>,
+    );
+    const radioInput = screen.getByTestId('radio-input');
+    fireEvent.click(radioInput);
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith('test-value');
+  });
+
+  it('disabled state works correctly', () => {
+    render(
+      <RadioGroup
+        name="test-radio"
+        selectedValue="test-value"
+        onValueChange={() => {}}
+        isDisabled
+      >
+        <RadioInput value="test-value">
+          <RadioInput.Field data-testid="radio-input" />
+          <RadioInput.Label data-testid="radio-label">
+            Test Label
+          </RadioInput.Label>
+        </RadioInput>
+      </RadioGroup>,
+    );
+
+    const radioInput = screen.getByTestId('radio-input');
+    const radioLabel = screen.getByTestId('radio-label');
+
+    expect(radioInput).toBeDisabled();
+    expect(radioLabel).toHaveAttribute('data-disabled', 'true');
+  });
+
+  it('handles focus and blur states correctly', () => {
+    const handleFocus = vi.fn();
+    const handleBlur = vi.fn();
+
+    render(
+      <RadioGroup
+        name="test-radio"
+        selectedValue="test-value"
+        onValueChange={() => {}}
+      >
+        <RadioInput value="test-value">
+          <RadioInput.Field
+            data-testid="radio-input"
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+          />
+          <RadioInput.Label>Test Label</RadioInput.Label>
+        </RadioInput>
+      </RadioGroup>,
+    );
+
+    const radioInput = screen.getByTestId('radio-input');
+
+    // Test focus
+    fireEvent.focus(radioInput);
+    expect(handleFocus).toHaveBeenCalledTimes(1);
+
+    // Test blur
+    fireEvent.blur(radioInput);
+    expect(handleBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it('Radio group with multiple options works correctly', () => {
+    const handleChange = vi.fn();
+
+    render(
+      <RadioGroup
+        name="test-group"
+        selectedValue="option1"
+        onValueChange={handleChange}
+      >
+        <RadioInput value="option1">
+          <RadioInput.Field data-testid="radio-1" />
+          <RadioInput.Label>Option 1</RadioInput.Label>
+        </RadioInput>
+        <RadioInput value="option2">
+          <RadioInput.Field data-testid="radio-2" />
+          <RadioInput.Label>Option 2</RadioInput.Label>
+        </RadioInput>
+      </RadioGroup>,
+    );
+
+    const radio1 = screen.getByTestId('radio-1');
+    const radio2 = screen.getByTestId('radio-2');
+
+    expect(radio1).toBeChecked();
+    expect(radio2).not.toBeChecked();
+
+    // Change selection
+    fireEvent.click(radio2);
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith('option2');
+  });
+});

--- a/packages/interfaces/ui-radio/src/atoms/index.ts
+++ b/packages/interfaces/ui-radio/src/atoms/index.ts
@@ -1,0 +1,7 @@
+/* eslint-disable import/max-dependencies */
+export * from './radio-helper-text';
+export * from './radio-input';
+export * from './radio-input-field';
+export * from './radio-input-label';
+export * from './radio-group';
+export * from './use-radio';

--- a/packages/interfaces/ui-radio/src/atoms/radio-container.tsx
+++ b/packages/interfaces/ui-radio/src/atoms/radio-container.tsx
@@ -1,0 +1,25 @@
+import { forwardRef, ReactNode, HTMLAttributes } from 'react';
+
+import { ElRadioContainer } from './style';
+import { RadioProvider } from './use-radio';
+
+export interface RadioContainerProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  hasError?: boolean;
+  isDisabled?: boolean;
+  isChecked?: boolean;
+  value: string;
+  children: ReactNode;
+}
+
+export const RadioContainer = forwardRef<HTMLDivElement, RadioContainerProps>(
+  ({ hasError = false, isDisabled = false, children, value, ...rest }, ref) => {
+    return (
+      <RadioProvider hasError={hasError} isDisabled={isDisabled} value={value}>
+        <ElRadioContainer ref={ref} {...rest}>
+          {children}
+        </ElRadioContainer>
+      </RadioProvider>
+    );
+  },
+);

--- a/packages/interfaces/ui-radio/src/atoms/radio-group.tsx
+++ b/packages/interfaces/ui-radio/src/atoms/radio-group.tsx
@@ -1,0 +1,42 @@
+import { forwardRef, HTMLAttributes, ReactNode } from 'react';
+
+import { ElRadioGroupContainer } from './style';
+import { RadioGroupProvider } from './use-radio-group';
+
+export interface RadioGroupProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  name: string;
+  selectedValue?: string;
+  onValueChange: (value: string) => void;
+  isDisabled?: boolean;
+  hasError?: boolean;
+}
+
+export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
+  (
+    {
+      children,
+      name,
+      selectedValue,
+      onValueChange,
+      isDisabled = false,
+      hasError = false,
+      ...rest
+    },
+    ref,
+  ) => {
+    return (
+      <RadioGroupProvider
+        name={name}
+        selectedValue={selectedValue}
+        onChange={onValueChange}
+        isDisabled={isDisabled}
+        hasError={hasError}
+      >
+        <ElRadioGroupContainer ref={ref} {...rest}>
+          {children}
+        </ElRadioGroupContainer>
+      </RadioGroupProvider>
+    );
+  },
+);

--- a/packages/interfaces/ui-radio/src/atoms/radio-helper-text.tsx
+++ b/packages/interfaces/ui-radio/src/atoms/radio-helper-text.tsx
@@ -1,0 +1,19 @@
+import { forwardRef, HTMLAttributes } from 'react';
+
+import { ElRadioHelperText } from './style';
+import { useRadio } from './use-radio';
+
+import type { ReactNode } from 'react';
+
+export interface RadioHelperTextProps extends HTMLAttributes<HTMLSpanElement> {
+  children: ReactNode;
+}
+
+export const RadioHelperText = forwardRef<
+  HTMLSpanElement,
+  RadioHelperTextProps
+>((props, ref) => {
+  const { getAttributes } = useRadio();
+
+  return <ElRadioHelperText ref={ref} {...props} {...getAttributes()} />;
+});

--- a/packages/interfaces/ui-radio/src/atoms/radio-input-field.tsx
+++ b/packages/interfaces/ui-radio/src/atoms/radio-input-field.tsx
@@ -1,0 +1,59 @@
+import { forwardRef, InputHTMLAttributes, FocusEvent } from 'react';
+
+import { ElRadioWrapper, ElRadioInput, ElRadioCircle } from './style';
+import { useRadio } from './use-radio';
+
+type RadioInputFieldProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'checked' | 'disabled' | 'type' | 'onChange'
+>;
+
+export const RadioInputField = forwardRef<
+  HTMLInputElement,
+  RadioInputFieldProps
+>(({ id, onFocus, onBlur, ...rest }, ref) => {
+  const {
+    isDisabled,
+    isChecked,
+    radioId,
+    name,
+    value,
+    onChange,
+    getAttributes,
+    setIsFocused,
+  } = useRadio();
+
+  const handleFocus = (e: FocusEvent<HTMLInputElement>) => {
+    setIsFocused(true);
+    onFocus?.(e);
+  };
+
+  const handleBlur = (e: FocusEvent<HTMLInputElement>) => {
+    setIsFocused(false);
+    onBlur?.(e);
+  };
+
+  const handleChange = () => {
+    // Always call onChange with the radio value
+    onChange(value);
+  };
+
+  return (
+    <ElRadioWrapper {...getAttributes()}>
+      <ElRadioInput
+        ref={ref}
+        id={id || radioId}
+        name={name}
+        value={value}
+        type="radio"
+        checked={isChecked}
+        disabled={isDisabled}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onChange={handleChange}
+        {...rest}
+      />
+      <ElRadioCircle data-disabled={isDisabled} />
+    </ElRadioWrapper>
+  );
+});

--- a/packages/interfaces/ui-radio/src/atoms/radio-input-label.tsx
+++ b/packages/interfaces/ui-radio/src/atoms/radio-input-label.tsx
@@ -1,0 +1,27 @@
+import { forwardRef, HTMLAttributes, ReactNode } from 'react';
+
+import { ElRadioLabel } from './style';
+import { useRadio } from './use-radio';
+
+export interface RadioInputLabelProps extends HTMLAttributes<HTMLLabelElement> {
+  children: ReactNode;
+  htmlFor?: string;
+}
+
+export const RadioInputLabel = forwardRef<
+  HTMLLabelElement,
+  RadioInputLabelProps
+>(({ children, htmlFor, ...props }, ref) => {
+  const { radioId, getAttributes } = useRadio();
+
+  return (
+    <ElRadioLabel
+      ref={ref}
+      htmlFor={htmlFor || radioId}
+      {...props}
+      {...getAttributes()}
+    >
+      {children}
+    </ElRadioLabel>
+  );
+});

--- a/packages/interfaces/ui-radio/src/atoms/radio-input.tsx
+++ b/packages/interfaces/ui-radio/src/atoms/radio-input.tsx
@@ -1,0 +1,23 @@
+import { forwardRef, ReactNode, HTMLAttributes } from 'react';
+
+import { ElRadioContainer } from './style';
+import { RadioProvider } from './use-radio';
+
+export interface RadioInputProps extends HTMLAttributes<HTMLDivElement> {
+  hasError?: boolean;
+  isDisabled?: boolean;
+  value: string;
+  children: ReactNode;
+}
+
+export const RadioInput = forwardRef<HTMLDivElement, RadioInputProps>(
+  ({ hasError = false, isDisabled = false, value, children, ...rest }, ref) => {
+    return (
+      <RadioProvider hasError={hasError} isDisabled={isDisabled} value={value}>
+        <ElRadioContainer ref={ref} {...rest}>
+          {children}
+        </ElRadioContainer>
+      </RadioProvider>
+    );
+  },
+);

--- a/packages/interfaces/ui-radio/src/atoms/radio-label.tsx
+++ b/packages/interfaces/ui-radio/src/atoms/radio-label.tsx
@@ -1,0 +1,26 @@
+import { forwardRef, HTMLAttributes, ReactNode } from 'react';
+
+import { ElRadioLabel } from './style';
+import { useRadio } from './use-radio';
+
+export interface RadioLabelProps extends HTMLAttributes<HTMLLabelElement> {
+  children: ReactNode;
+  htmlFor?: string;
+}
+
+export const RadioLabel = forwardRef<HTMLLabelElement, RadioLabelProps>(
+  ({ children, htmlFor, ...props }, ref) => {
+    const { radioId, getAttributes } = useRadio();
+
+    return (
+      <ElRadioLabel
+        ref={ref}
+        htmlFor={htmlFor || radioId}
+        {...props}
+        {...getAttributes()}
+      >
+        {children}
+      </ElRadioLabel>
+    );
+  },
+);

--- a/packages/interfaces/ui-radio/src/atoms/style.ts
+++ b/packages/interfaces/ui-radio/src/atoms/style.ts
@@ -1,0 +1,118 @@
+import { styled } from '@linaria/react';
+
+export const ElRadioContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--components-radio-gap);
+  position: relative;
+  width: 100%;
+`;
+
+export const ElRadioLabel = styled.label`
+  font-size: var(--components-radio-font-size-label);
+  line-height: var(--components-radio-line-height-label);
+  font-weight: var(--components-radio-font-weight-label);
+  color: var(--components-radio-colors-label);
+  cursor: pointer;
+  margin-left: 8px;
+
+  &[data-disabled='true'] {
+    opacity: 0.32;
+    cursor: not-allowed;
+  }
+`;
+
+export const ElRadioCircle = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--components-radio-size);
+  height: var(--components-radio-size);
+  border-radius: 50%;
+  border: 2px solid var(--components-radio-colors-border-unchecked);
+  transition: border-color var(--components-radio-transition-duration)
+    var(--components-radio-transition-timing);
+  background-color: var(--components-radio-colors-background-unchecked);
+
+  &::after {
+    content: '';
+    position: absolute;
+    width: calc(var(--components-radio-size) / 2);
+    height: calc(var(--components-radio-size) / 2);
+    border-radius: 50%;
+    background-color: var(--components-radio-colors-dot);
+    transform: scale(0);
+    transition: transform var(--components-radio-transition-duration)
+      var(--components-radio-transition-timing);
+  }
+
+  [data-checked='true'] & {
+    border-color: var(--components-radio-colors-border-checked);
+
+    &::after {
+      transform: scale(1);
+    }
+  }
+
+  &[data-disabled='true'] {
+    opacity: 0.32;
+    cursor: not-allowed;
+    border-color: var(--components-radio-colors-border-disabled);
+  }
+`;
+
+export const ElRadioInput = styled.input`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  z-index: 1;
+  margin: 0;
+  cursor: pointer;
+
+  &:focus-visible + ${ElRadioCircle} {
+    outline: 2px solid var(--components-radio-colors-focus-ring);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+`;
+
+export const ElRadioHelperText = styled.span`
+  font-size: var(--components-radio-font-size-helper);
+  line-height: var(--components-radio-line-height-helper);
+  color: var(--components-radio-colors-helper-text-normal);
+  padding: var(--space-none) var(--space-3);
+  flex-basis: 100%;
+  margin-top: calc(var(--components-radio-gap) / 2);
+
+  &[data-error='true'] {
+    color: var(--components-radio-colors-helper-text-error);
+  }
+
+  &[data-disabled='true'] {
+    opacity: 0.32;
+  }
+`;
+
+export const ElRadioWrapper = styled.div`
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+
+  &[data-disabled='true'] {
+    cursor: not-allowed;
+  }
+`;
+
+export const ElRadioGroupContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--components-radio-group-gap);
+`;

--- a/packages/interfaces/ui-radio/src/atoms/use-radio-group.tsx
+++ b/packages/interfaces/ui-radio/src/atoms/use-radio-group.tsx
@@ -1,0 +1,50 @@
+import { createContext, useContext, ReactNode } from 'react';
+
+// Radio Group Context
+interface RadioGroupContextType {
+  name: string;
+  selectedValue?: string;
+  onChange: (value: string) => void;
+  isDisabled: boolean;
+  hasError: boolean;
+}
+
+const RadioGroupContext = createContext<RadioGroupContextType | undefined>(
+  undefined,
+);
+
+export const useRadioGroup = () => {
+  return useContext(RadioGroupContext);
+};
+
+interface RadioGroupProviderProps {
+  children: ReactNode;
+  name: string;
+  selectedValue?: string;
+  onChange: (value: string) => void;
+  isDisabled: boolean;
+  hasError: boolean;
+}
+
+export const RadioGroupProvider = ({
+  children,
+  name,
+  selectedValue,
+  onChange,
+  isDisabled,
+  hasError,
+}: RadioGroupProviderProps) => {
+  return (
+    <RadioGroupContext.Provider
+      value={{
+        name,
+        selectedValue,
+        onChange,
+        isDisabled,
+        hasError,
+      }}
+    >
+      {children}
+    </RadioGroupContext.Provider>
+  );
+};

--- a/packages/interfaces/ui-radio/src/atoms/use-radio.tsx
+++ b/packages/interfaces/ui-radio/src/atoms/use-radio.tsx
@@ -1,0 +1,85 @@
+import { createContext, useContext, ReactNode, useState, useId } from 'react';
+
+import { useRadioGroup } from './use-radio-group';
+
+// Radio Context
+interface RadioContextType {
+  hasError: boolean;
+  isDisabled: boolean;
+  isChecked: boolean;
+  isFocused: boolean;
+  radioId: string;
+  value: string;
+  name: string;
+  onChange: (value: string) => void;
+  setIsFocused: (focused: boolean) => void;
+  getAttributes: () => Record<string, boolean | string>;
+}
+
+const RadioContext = createContext<RadioContextType | undefined>(undefined);
+
+export const useRadio = () => {
+  const context = useContext(RadioContext);
+  if (!context) {
+    throw new Error('useRadio must be used within a RadioProvider');
+  }
+  return context;
+};
+
+interface RadioProviderProps {
+  children: ReactNode;
+  hasError?: boolean;
+  isDisabled?: boolean;
+  value: string;
+}
+
+export const RadioProvider = ({
+  children,
+  hasError = false,
+  isDisabled = false,
+  value,
+}: RadioProviderProps) => {
+  const [isFocused, setIsFocused] = useState(false);
+  const radioId = useId();
+
+  // Get values from RadioGroup if available
+  const radioGroup = useRadioGroup();
+
+  // Derive values from RadioGroup when available, otherwise use props
+  const effectiveHasError = radioGroup?.hasError || hasError;
+  const effectiveIsDisabled = radioGroup?.isDisabled || isDisabled;
+  const isChecked = radioGroup ? radioGroup.selectedValue === value : false;
+  const name = radioGroup?.name || '';
+  const onChange = radioGroup?.onChange || (() => {});
+
+  const getAttributes = () => {
+    const attributes: Record<string, boolean | string> = {
+      'data-error': effectiveHasError,
+      'data-disabled': effectiveIsDisabled,
+      'data-checked': isChecked,
+      'data-is-focused': isFocused,
+      'data-is-blurred': !isFocused,
+    };
+
+    return attributes;
+  };
+
+  return (
+    <RadioContext.Provider
+      value={{
+        hasError: effectiveHasError,
+        isDisabled: effectiveIsDisabled,
+        isChecked,
+        isFocused,
+        radioId,
+        value,
+        name,
+        onChange,
+        setIsFocused,
+        getAttributes,
+      }}
+    >
+      {children}
+    </RadioContext.Provider>
+  );
+};

--- a/packages/interfaces/ui-radio/src/index.ts
+++ b/packages/interfaces/ui-radio/src/index.ts
@@ -1,0 +1,28 @@
+import {
+  RadioGroup as RadioGroupComponent,
+  RadioInput as RadioInputComponent,
+  RadioInputField,
+  RadioInputLabel,
+  RadioHelperText,
+} from './atoms';
+
+// RadioInput compound component
+type CompoundRadioInputProps = {
+  Field: typeof RadioInputField;
+  Label: typeof RadioInputLabel;
+  HelperText: typeof RadioHelperText;
+};
+
+const CompoundRadioInput = {
+  Field: RadioInputField,
+  Label: RadioInputLabel,
+  HelperText: RadioHelperText,
+} satisfies CompoundRadioInputProps;
+
+export const RadioInput = Object.assign(
+  RadioInputComponent,
+  CompoundRadioInput,
+);
+
+// Export RadioGroup directly
+export const RadioGroup = RadioGroupComponent;

--- a/packages/interfaces/ui-radio/src/story.tsx
+++ b/packages/interfaces/ui-radio/src/story.tsx
@@ -1,0 +1,252 @@
+import { useState } from 'react';
+
+import { RadioGroup, RadioInput } from '.';
+
+import type { Meta, StoryObj } from '@react-beauty/storybook';
+import type { ReactNode } from 'react';
+
+const meta = {
+  title: 'Radio',
+  component: RadioGroup,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    backgrounds: {
+      default: 'light',
+      values: [
+        {
+          name: 'light',
+          value: 'var(--colors-main-goku)',
+        },
+      ],
+    },
+  },
+  args: {
+    name: 'radio-name',
+    selectedValue: '',
+    onValueChange: () => {},
+    children: null as unknown as ReactNode,
+  },
+} satisfies Meta<typeof RadioGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    name: 'basic-radio',
+    selectedValue: 'option1',
+    onValueChange: () => {},
+  },
+  render: (args) => (
+    <RadioGroup {...args}>
+      <RadioInput value="option1">
+        <RadioInput.Field />
+        <RadioInput.Label>Option 1</RadioInput.Label>
+      </RadioInput>
+    </RadioGroup>
+  ),
+};
+
+export const WithHelperText: Story = {
+  args: {
+    name: 'helper-radio',
+    selectedValue: 'option1',
+    onValueChange: () => {},
+  },
+  render: (args) => (
+    <RadioGroup {...args}>
+      <RadioInput value="option1">
+        <RadioInput.Field />
+        <RadioInput.Label>Option 1</RadioInput.Label>
+        <RadioInput.HelperText>This is a helper text</RadioInput.HelperText>
+      </RadioInput>
+    </RadioGroup>
+  ),
+};
+
+export const WithError: Story = {
+  args: {
+    name: 'error-radio',
+    selectedValue: 'option1',
+    onValueChange: () => {},
+    hasError: true,
+  },
+  render: (args) => (
+    <RadioGroup {...args}>
+      <RadioInput value="option1">
+        <RadioInput.Field />
+        <RadioInput.Label>Option 1</RadioInput.Label>
+        <RadioInput.HelperText>This option has an error</RadioInput.HelperText>
+      </RadioInput>
+    </RadioGroup>
+  ),
+};
+
+export const Disabled: Story = {
+  args: {
+    name: 'disabled-radio',
+    selectedValue: 'option1',
+    onValueChange: () => {},
+    isDisabled: true,
+  },
+  render: (args) => (
+    <RadioGroup {...args}>
+      <RadioInput value="option1">
+        <RadioInput.Field />
+        <RadioInput.Label>Option 1</RadioInput.Label>
+        <RadioInput.HelperText>This option is disabled</RadioInput.HelperText>
+      </RadioInput>
+    </RadioGroup>
+  ),
+};
+
+export const RadioGroupExample: Story = {
+  args: {
+    name: 'radio-group',
+  },
+  render: () => {
+    const [selectedValue, setSelectedValue] = useState('option1');
+
+    return (
+      <RadioGroup
+        name="radio-group"
+        selectedValue={selectedValue}
+        onValueChange={setSelectedValue}
+      >
+        <RadioInput value="option1">
+          <RadioInput.Field data-testid="radio-1" />
+          <RadioInput.Label>Option 1</RadioInput.Label>
+        </RadioInput>
+        <RadioInput value="option2">
+          <RadioInput.Field data-testid="radio-2" />
+          <RadioInput.Label>Option 2</RadioInput.Label>
+        </RadioInput>
+        <RadioInput value="option3">
+          <RadioInput.Field data-testid="radio-3" />
+          <RadioInput.Label>Option 3</RadioInput.Label>
+        </RadioInput>
+      </RadioGroup>
+    );
+  },
+};
+
+export const RadioGroupWithError: Story = {
+  args: {
+    name: 'error-radio-group',
+    hasError: true,
+  },
+  render: () => {
+    const [selectedValue, setSelectedValue] = useState('');
+
+    return (
+      <>
+        <RadioGroup
+          name="error-radio-group"
+          selectedValue={selectedValue}
+          onValueChange={setSelectedValue}
+          hasError
+        >
+          <RadioInput value="option1">
+            <RadioInput.Field />
+            <RadioInput.Label>Option 1</RadioInput.Label>
+          </RadioInput>
+          <RadioInput value="option2">
+            <RadioInput.Field />
+            <RadioInput.Label>Option 2</RadioInput.Label>
+          </RadioInput>
+          <RadioInput value="option3">
+            <RadioInput.Field />
+            <RadioInput.Label>Option 3</RadioInput.Label>
+          </RadioInput>
+        </RadioGroup>
+        <div
+          style={{ marginTop: '8px', color: 'var(--colors-supportive-chichi)' }}
+        >
+          Please select an option
+        </div>
+      </>
+    );
+  },
+};
+
+export const RadioGroupDisabled: Story = {
+  args: {
+    name: 'disabled-radio-group',
+    isDisabled: true,
+  },
+  render: () => {
+    const [selectedValue, setSelectedValue] = useState('option2');
+
+    return (
+      <RadioGroup
+        name="disabled-radio-group"
+        selectedValue={selectedValue}
+        onValueChange={setSelectedValue}
+        isDisabled
+      >
+        <RadioInput value="option1">
+          <RadioInput.Field />
+          <RadioInput.Label>Option 1</RadioInput.Label>
+        </RadioInput>
+        <RadioInput value="option2">
+          <RadioInput.Field />
+          <RadioInput.Label>Option 2</RadioInput.Label>
+        </RadioInput>
+        <RadioInput value="option3">
+          <RadioInput.Field />
+          <RadioInput.Label>Option 3</RadioInput.Label>
+        </RadioInput>
+      </RadioGroup>
+    );
+  },
+};
+
+export const Interactive: Story = {
+  args: {
+    name: 'interactive-radio-group',
+  },
+  render: () => {
+    const [selectedValue, setSelectedValue] = useState('');
+    const [error, setError] = useState(true);
+
+    const handleChange = (value: string) => {
+      setSelectedValue(value);
+      setError(false);
+    };
+
+    return (
+      <>
+        <RadioGroup
+          name="interactive-radio-group"
+          selectedValue={selectedValue}
+          onValueChange={handleChange}
+          hasError={error}
+        >
+          <RadioInput value="option1">
+            <RadioInput.Field />
+            <RadioInput.Label>Small</RadioInput.Label>
+          </RadioInput>
+          <RadioInput value="option2">
+            <RadioInput.Field />
+            <RadioInput.Label>Medium</RadioInput.Label>
+          </RadioInput>
+          <RadioInput value="option3">
+            <RadioInput.Field />
+            <RadioInput.Label>Large</RadioInput.Label>
+          </RadioInput>
+        </RadioGroup>
+        {error && (
+          <div
+            style={{
+              marginTop: '8px',
+              color: 'var(--colors-supportive-chichi)',
+            }}
+          >
+            Please select a size
+          </div>
+        )}
+      </>
+    );
+  },
+};

--- a/packages/interfaces/ui-radio/src/tokens/dark.json
+++ b/packages/interfaces/ui-radio/src/tokens/dark.json
@@ -1,0 +1,42 @@
+{
+  "components": {
+    "radio": {
+      "border-radius": { "value": "{border-radius.rounded}" },
+      "size": { "value": "20px" },
+      "transition-duration": { "value": "0.2s" },
+      "transition-timing": { "value": "ease-in-out" },
+      "font-size": {
+        "label": { "value": "{font-size.sm}" },
+        "helper": { "value": "{font-size.xs}" }
+      },
+      "line-height": {
+        "label": { "value": "{font-line-height.sm}" },
+        "helper": { "value": "{font-line-height.xs}" }
+      },
+      "font-weight": {
+        "label": { "value": "{font-weight.medium}" }
+      },
+      "gap": { "value": "{space.1}" },
+      "group-gap": { "value": "{space.2}" },
+      "colors": {
+        "label": { "value": "{colors.main.bulma}" },
+        "border": {
+          "unchecked": { "value": "{colors.main.trunks}" },
+          "checked": { "value": "{colors.main.picollo}" },
+          "disabled": { "value": "{colors.main.beerus}" }
+        },
+        "background": {
+          "unchecked": { "value": "{colors.main.gohan}" },
+          "checked": { "value": "{colors.main.gohan}" },
+          "disabled": { "value": "{colors.main.gohan}" }
+        },
+        "dot": { "value": "{colors.main.picollo}" },
+        "focus-ring": { "value": "{colors.supportive.whis-60}" },
+        "helper-text": {
+          "normal": { "value": "{colors.main.trunks}" },
+          "error": { "value": "{colors.supportive.chichi}" }
+        }
+      }
+    }
+  }
+}

--- a/packages/interfaces/ui-radio/src/tokens/light.json
+++ b/packages/interfaces/ui-radio/src/tokens/light.json
@@ -1,0 +1,42 @@
+{
+  "components": {
+    "radio": {
+      "border-radius": { "value": "{border-radius.rounded}" },
+      "size": { "value": "20px" },
+      "transition-duration": { "value": "0.2s" },
+      "transition-timing": { "value": "ease-in-out" },
+      "font-size": {
+        "label": { "value": "{font-size.sm}" },
+        "helper": { "value": "{font-size.xs}" }
+      },
+      "line-height": {
+        "label": { "value": "{font-line-height.sm}" },
+        "helper": { "value": "{font-line-height.xs}" }
+      },
+      "font-weight": {
+        "label": { "value": "{font-weight.medium}" }
+      },
+      "gap": { "value": "{space.1}" },
+      "group-gap": { "value": "{space.2}" },
+      "colors": {
+        "label": { "value": "{colors.main.bulma}" },
+        "border": {
+          "unchecked": { "value": "{colors.main.trunks}" },
+          "checked": { "value": "{colors.main.picollo}" },
+          "disabled": { "value": "{colors.main.beerus}" }
+        },
+        "background": {
+          "unchecked": { "value": "{colors.main.gohan}" },
+          "checked": { "value": "{colors.main.gohan}" },
+          "disabled": { "value": "{colors.main.gohan}" }
+        },
+        "dot": { "value": "{colors.main.picollo}" },
+        "focus-ring": { "value": "{colors.supportive.whis-60}" },
+        "helper-text": {
+          "normal": { "value": "{colors.main.trunks}" },
+          "error": { "value": "{colors.supportive.chichi}" }
+        }
+      }
+    }
+  }
+}

--- a/packages/interfaces/ui-radio/tsconfig.json
+++ b/packages/interfaces/ui-radio/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@react-beauty/tsc/react",
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "__tests__"
+  ]
+}

--- a/packages/interfaces/ui-radio/vite.config.ts
+++ b/packages/interfaces/ui-radio/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig, viteConfig } from "@react-beauty/vite/package";
+
+import packageManifest from "./package.json";
+
+export default defineConfig(viteConfig(packageManifest));

--- a/packages/interfaces/ui-radio/vitest.config.ts
+++ b/packages/interfaces/ui-radio/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig, vitestConfig } from '@react-beauty/vitest';
+
+import packageManifest from './package.json';
+
+const { name } = packageManifest ?? {};
+export default defineConfig(vitestConfig({ name }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1212,6 +1212,7 @@ __metadata:
     "@react-beauty/ui-icon": "workspace:*"
     "@react-beauty/ui-menu-item": "workspace:*"
     "@react-beauty/ui-pagination": "workspace:*"
+    "@react-beauty/ui-radio": "workspace:*"
     "@react-beauty/ui-switch": "workspace:*"
     "@react-beauty/ui-tag": "workspace:*"
     "@react-beauty/ui-text-area": "workspace:*"
@@ -1426,6 +1427,23 @@ __metadata:
     "@react-beauty/storybook": "workspace:*"
     "@react-beauty/tsc": "workspace:*"
     "@react-beauty/ui-icon": "workspace:*"
+    "@react-beauty/vite": "workspace:*"
+    "@react-beauty/vitest": "workspace:*"
+  peerDependencies:
+    "@types/react": ^18.0
+    react: ^18.0
+  languageName: unknown
+  linkType: soft
+
+"@react-beauty/ui-radio@workspace:*, @react-beauty/ui-radio@workspace:packages/interfaces/ui-radio":
+  version: 0.0.0-use.local
+  resolution: "@react-beauty/ui-radio@workspace:packages/interfaces/ui-radio"
+  dependencies:
+    "@linaria/core": "npm:6.3.0"
+    "@linaria/react": "npm:6.3.0"
+    "@react-beauty/eslint": "workspace:*"
+    "@react-beauty/storybook": "workspace:*"
+    "@react-beauty/tsc": "workspace:*"
     "@react-beauty/vite": "workspace:*"
     "@react-beauty/vitest": "workspace:*"
   peerDependencies:


### PR DESCRIPTION
- Implement RadioGroup and RadioInput components
- Add helper text and error state functionality
- Create disabled state for radio inputs
- Develop interactive radio group with validation
- Add unit tests for radio components
- Include storybook examples for various use cases
- Establish ESLint and TypeScript configurations
- Define styles and tokens for light and dark themes
- Update package.json and yarn.lock for new dependencies