### PR TITLE
feat(ui-select): add initial implementation of Select component with various subcomponents and styles

### DIFF
--- a/internal/storybook/.storybook/main.ts
+++ b/internal/storybook/.storybook/main.ts
@@ -31,6 +31,7 @@ const config: StorybookConfig = {
     getStoriesPath('interfaces/ui-switch'),
     getStoriesPath('interfaces/ui-radio'),
     getStoriesPath('interfaces/ui-checkbox'),
+    getStoriesPath('interfaces/ui-select'),
   ],
   addons: [
     getAbsolutePath('@storybook/addon-essentials'),

--- a/packages/interfaces/module/package.json
+++ b/packages/interfaces/module/package.json
@@ -41,6 +41,7 @@
     "@react-beauty/ui-menu-item": "workspace:*",
     "@react-beauty/ui-pagination": "workspace:*",
     "@react-beauty/ui-radio": "workspace:*",
+    "@react-beauty/ui-select": "workspace:*",
     "@react-beauty/ui-switch": "workspace:*",
     "@react-beauty/ui-tag": "workspace:*",
     "@react-beauty/ui-text-area": "workspace:*",

--- a/packages/interfaces/module/src/index.ts
+++ b/packages/interfaces/module/src/index.ts
@@ -17,3 +17,4 @@ export * from '@react-beauty/ui-text-area';
 export * from '@react-beauty/ui-switch';
 export * from '@react-beauty/ui-radio';
 export * from '@react-beauty/ui-checkbox';
+export * from '@react-beauty/ui-select';

--- a/packages/interfaces/ui-core/src/dark/index.css
+++ b/packages/interfaces/ui-core/src/dark/index.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 01 May 2025 08:27:24 GMT
+ * Generated on Fri, 02 May 2025 13:37:25 GMT
  */
 
 :root[data-theme='dark'] {
@@ -130,6 +130,7 @@
   --components-radio-size: 20px;
   --components-radio-transition-duration: 0.2s;
   --components-radio-transition-timing: ease-in-out;
+  --components-select-border-width: 1px;
   --components-switch-width: 40px;
   --components-switch-height: 24px;
   --components-switch-thumb-size: 18px;
@@ -334,6 +335,35 @@
   --components-radio-colors-focus-ring: var(--colors-supportive-whis-60);
   --components-radio-colors-helper-text-normal: var(--colors-main-trunks);
   --components-radio-colors-helper-text-error: var(--colors-supportive-chichi);
+  --components-select-border-radius: var(--border-radius-xs);
+  --components-select-font-size-label: var(--font-size-sm);
+  --components-select-font-size-input: var(--font-size-xs);
+  --components-select-font-size-helper: var(--font-size-xs);
+  --components-select-font-size-option: var(--font-size-xs);
+  --components-select-line-height-label: var(--font-line-height-sm);
+  --components-select-line-height-input: var(--font-line-height-xs);
+  --components-select-line-height-helper: var(--font-line-height-xs);
+  --components-select-line-height-option: var(--font-line-height-xs);
+  --components-select-font-weight-label: var(--font-weight-medium);
+  --components-select-font-weight-input: var(--font-weight-regular);
+  --components-select-font-weight-option: var(--font-weight-regular);
+  --components-select-padding-input-horizontal: var(--space-3);
+  --components-select-padding-input-vertical: var(--space-2);
+  --components-select-gap: var(--space-1);
+  --components-select-colors-label: var(--colors-main-bulma);
+  --components-select-colors-input-text: var(--colors-main-bulma);
+  --components-select-colors-placeholder: var(--colors-main-trunks);
+  --components-select-colors-border-rest: var(--colors-main-trunks);
+  --components-select-colors-border-hover: var(--colors-main-picollo);
+  --components-select-colors-border-focus: var(--colors-main-picollo);
+  --components-select-colors-border-error: var(--colors-supportive-chichi);
+  --components-select-colors-background-rest: var(--colors-main-gohan);
+  --components-select-colors-background-outline: var(--colors-main-trunks);
+  --components-select-colors-background-disabled: var(--colors-supportive-krilin);
+  --components-select-colors-background-option-hover: var(--colors-main-picollo);
+  --components-select-colors-background-option-selected: var(--colors-main-picollo);
+  --components-select-colors-helper-text-normal: var(--colors-main-trunks);
+  --components-select-colors-helper-text-error: var(--colors-supportive-chichi);
   --components-switch-border-radius: var(--border-radius-rounded);
   --components-switch-font-size-label: var(--font-size-sm);
   --components-switch-font-size-helper: var(--font-size-xs);

--- a/packages/interfaces/ui-core/src/light/index.css
+++ b/packages/interfaces/ui-core/src/light/index.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Thu, 01 May 2025 08:27:24 GMT
+ * Generated on Fri, 02 May 2025 13:37:25 GMT
  */
 
 :root[data-theme='light'] {
@@ -130,6 +130,7 @@
   --components-radio-size: 20px;
   --components-radio-transition-duration: 0.2s;
   --components-radio-transition-timing: ease-in-out;
+  --components-select-border-width: 1px;
   --components-switch-width: 40px;
   --components-switch-height: 24px;
   --components-switch-thumb-size: 18px;
@@ -334,6 +335,35 @@
   --components-radio-colors-focus-ring: var(--colors-supportive-whis-60);
   --components-radio-colors-helper-text-normal: var(--colors-main-trunks);
   --components-radio-colors-helper-text-error: var(--colors-supportive-chichi);
+  --components-select-border-radius: var(--border-radius-xs);
+  --components-select-font-size-label: var(--font-size-sm);
+  --components-select-font-size-input: var(--font-size-xs);
+  --components-select-font-size-helper: var(--font-size-xs);
+  --components-select-font-size-option: var(--font-size-xs);
+  --components-select-line-height-label: var(--font-line-height-sm);
+  --components-select-line-height-input: var(--font-line-height-xs);
+  --components-select-line-height-helper: var(--font-line-height-xs);
+  --components-select-line-height-option: var(--font-line-height-xs);
+  --components-select-font-weight-label: var(--font-weight-medium);
+  --components-select-font-weight-input: var(--font-weight-regular);
+  --components-select-font-weight-option: var(--font-weight-regular);
+  --components-select-padding-input-horizontal: var(--space-3);
+  --components-select-padding-input-vertical: var(--space-2);
+  --components-select-gap: var(--space-1);
+  --components-select-colors-label: var(--colors-main-bulma);
+  --components-select-colors-input-text: var(--colors-main-bulma);
+  --components-select-colors-placeholder: var(--colors-main-trunks);
+  --components-select-colors-border-rest: var(--colors-main-trunks);
+  --components-select-colors-border-hover: var(--colors-main-picollo);
+  --components-select-colors-border-focus: var(--colors-main-picollo);
+  --components-select-colors-border-error: var(--colors-supportive-chichi);
+  --components-select-colors-background-rest: var(--colors-main-gohan);
+  --components-select-colors-background-outline: var(--colors-main-trunks);
+  --components-select-colors-background-disabled: var(--colors-supportive-krilin);
+  --components-select-colors-background-option-hover: var(--colors-main-picollo);
+  --components-select-colors-background-option-selected: var(--colors-main-picollo);
+  --components-select-colors-helper-text-normal: var(--colors-main-trunks);
+  --components-select-colors-helper-text-error: var(--colors-supportive-chichi);
   --components-switch-border-radius: var(--border-radius-rounded);
   --components-switch-font-size-label: var(--font-size-sm);
   --components-switch-font-size-helper: var(--font-size-xs);

--- a/packages/interfaces/ui-select/README.md
+++ b/packages/interfaces/ui-select/README.md
@@ -1,0 +1,212 @@
+# UI Select Component
+
+A flexible, accessible select component for React Beauty that uses native HTML select elements to provide the best accessibility and platform consistency.
+
+## Installation
+
+```bash
+npm install @react-beauty/ui-select
+```
+
+## Usage
+
+The UI Select component uses a compound component pattern for flexibility and easy composition.
+
+### Basic Usage
+
+```tsx
+import { Select } from '@react-beauty/ui-select';
+
+function Example() {
+  return (
+    <Select>
+      <Select.Label>Choose an option</Select.Label>
+      <Select.Field placeholder="Select an option">
+        <Select.Option value="option1">Option 1</Select.Option>
+        <Select.Option value="option2">Option 2</Select.Option>
+        <Select.Option value="option3">Option 3</Select.Option>
+      </Select.Field>
+    </Select>
+  );
+}
+```
+
+### Controlled Select
+
+```tsx
+import { useState } from 'react';
+import { Select } from '@react-beauty/ui-select';
+
+function ControlledExample() {
+  const [value, setValue] = useState('option1');
+  
+  const handleChange = (newValue: string) => {
+    setValue(newValue);
+  };
+  
+  return (
+    <Select value={value} onValueChange={handleChange}>
+      <Select.Label>Controlled select</Select.Label>
+      <Select.Field>
+        <Select.Option value="option1">Option 1</Select.Option>
+        <Select.Option value="option2">Option 2</Select.Option>
+        <Select.Option value="option3">Option 3</Select.Option>
+      </Select.Field>
+      <Select.HelperText>Selected value: {value}</Select.HelperText>
+    </Select>
+  );
+}
+```
+
+### With Helper Text
+
+```tsx
+<Select>
+  <Select.Label>Choose an option</Select.Label>
+  <Select.Field placeholder="Select an option">
+    <Select.Option value="option1">Option 1</Select.Option>
+    <Select.Option value="option2">Option 2</Select.Option>
+    <Select.Option value="option3">Option 3</Select.Option>
+  </Select.Field>
+  <Select.HelperText>
+    Please select one option from the list
+  </Select.HelperText>
+</Select>
+```
+
+### With Error State
+
+```tsx
+<Select hasError>
+  <Select.Label>Choose an option</Select.Label>
+  <Select.Field placeholder="Select an option">
+    <Select.Option value="option1">Option 1</Select.Option>
+    <Select.Option value="option2">Option 2</Select.Option>
+    <Select.Option value="option3">Option 3</Select.Option>
+  </Select.Field>
+  <Select.HelperText>This field is required</Select.HelperText>
+</Select>
+```
+
+### Disabled Select
+
+```tsx
+<Select isDisabled>
+  <Select.Label>Choose an option</Select.Label>
+  <Select.Field placeholder="Select an option">
+    <Select.Option value="option1">Option 1</Select.Option>
+    <Select.Option value="option2">Option 2</Select.Option>
+    <Select.Option value="option3">Option 3</Select.Option>
+  </Select.Field>
+  <Select.HelperText>This field is disabled</Select.HelperText>
+</Select>
+```
+
+### With Disabled Option
+
+```tsx
+<Select>
+  <Select.Label>Choose an option</Select.Label>
+  <Select.Field placeholder="Select an option">
+    <Select.Option value="option1">Option 1</Select.Option>
+    <Select.Option value="option2" disabled>
+      Option 2 (Disabled)
+    </Select.Option>
+    <Select.Option value="option3">Option 3</Select.Option>
+  </Select.Field>
+</Select>
+```
+
+### With Lead Element (Icon)
+
+```tsx
+<Select>
+  <Select.Label>Choose an option</Select.Label>
+  <Select.Field placeholder="Select an option">
+    <Select.LeadElement>
+      <span style={{ fontSize: '14px' }}>🔍</span>
+    </Select.LeadElement>
+    <Select.Option value="option1">Option 1</Select.Option>
+    <Select.Option value="option2">Option 2</Select.Option>
+    <Select.Option value="option3">Option 3</Select.Option>
+  </Select.Field>
+</Select>
+```
+
+### With Trail Element (Custom Dropdown Icon)
+
+```tsx
+<Select>
+  <Select.Label>Choose an option</Select.Label>
+  <Select.Field placeholder="Select an option">
+    <Select.TrailElement>
+      <ArrowDownIcon />
+    </Select.TrailElement>
+    <Select.Option value="option1">Option 1</Select.Option>
+    <Select.Option value="option2">Option 2</Select.Option>
+    <Select.Option value="option3">Option 3</Select.Option>
+  </Select.Field>
+</Select>
+```
+
+### With Both Lead and Trail Elements
+
+```tsx
+<Select>
+  <Select.Label>Choose an option</Select.Label>
+  <Select.Field placeholder="Select an option">
+    <Select.LeadElement>
+      <span style={{ fontSize: '14px' }}>🔍</span>
+    </Select.LeadElement>
+    <Select.TrailElement>
+      <ArrowDownIcon />
+    </Select.TrailElement>
+    <Select.Option value="option1">Option 1</Select.Option>
+    <Select.Option value="option2">Option 2</Select.Option>
+    <Select.Option value="option3">Option 3</Select.Option>
+  </Select.Field>
+</Select>
+```
+
+## Props
+
+### Select Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `hasError` | boolean | `false` | Shows the component in error state |
+| `isDisabled` | boolean | `false` | Disables the select component |
+| `value` | string | `undefined` | The current value (for controlled component) |
+| `onValueChange` | (value: string) => void | `undefined` | Callback function called when selection changes |
+
+### Select.Field Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `placeholder` | string | `undefined` | Placeholder text when no option is selected |
+| `onChange` | (event: React.ChangeEvent<HTMLSelectElement>) => void | `undefined` | Callback function called when selection changes |
+
+### Select.Option Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | string | required | The value of the option |
+| `disabled` | boolean | `false` | Disables the individual option |
+
+## Accessibility
+
+The UI Select component leverages the native HTML `<select>` element, which provides:
+
+- Built-in keyboard navigation
+- Screen reader announcements
+- Focus management
+- Platform-native behaviors and styling
+- Native mobile experiences
+
+## Customization
+
+The Select component uses CSS variables for styling, allowing for easy customization through the design token system. You can customize the appearance by overriding these CSS variables in your application.
+
+## Styling
+
+When the select component is in a disabled state, it uses an opacity of 0.32 to visually indicate the disabled state while maintaining the same background color as the normal state.

--- a/packages/interfaces/ui-select/eslint.config.js
+++ b/packages/interfaces/ui-select/eslint.config.js
@@ -1,0 +1,3 @@
+import { configs } from "@react-beauty/eslint";
+
+export default configs;

--- a/packages/interfaces/ui-select/package.json
+++ b/packages/interfaces/ui-select/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@react-beauty/ui-select",
+  "description": "ui-select",
+  "license": "MIT",
+  "version": "1.0.0",
+  "stableVersion": "1.0.0",
+  "keywords": [
+    "react",
+    "@react-beauty",
+    "ui-select"
+  ],
+  "author": "Dimas Bagus P <dimas.bagus.pm1@gmail.com>",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "type": "./dist/index.d.ts"
+  },
+  "scripts": {
+    "lint": "eslint src",
+    "check": "tsc --noEmit",
+    "build": "vite build --configLoader runner",
+    "test": "vitest run --configLoader runner"
+  },
+  "dependencies": {
+    "@linaria/core": "6.3.0",
+    "@linaria/react": "6.3.0"
+  },
+  "peerDependencies": {
+    "@types/react": "^18.0",
+    "react": "^18.0"
+  },
+  "devDependencies": {
+    "@react-beauty/eslint": "workspace:*",
+    "@react-beauty/storybook": "workspace:*",
+    "@react-beauty/tsc": "workspace:*",
+    "@react-beauty/vite": "workspace:*",
+    "@react-beauty/vitest": "workspace:*"
+  }
+}

--- a/packages/interfaces/ui-select/src/__tests__/select.test.tsx
+++ b/packages/interfaces/ui-select/src/__tests__/select.test.tsx
@@ -54,7 +54,7 @@ describe('Select', () => {
     const handleChange = vi.fn();
 
     render(
-      <Select onChange={handleChange}>
+      <Select onValueChange={handleChange}>
         <Select.Field data-testid="select-field">
           <Select.Option value="option1">Option 1</Select.Option>
           <Select.Option value="option2">Option 2</Select.Option>

--- a/packages/interfaces/ui-select/src/__tests__/select.test.tsx
+++ b/packages/interfaces/ui-select/src/__tests__/select.test.tsx
@@ -1,0 +1,155 @@
+import { render, screen, fireEvent } from '@react-beauty/vitest/selector';
+import { vi } from 'vitest';
+
+import { Select } from '..';
+
+describe('Select', () => {
+  it('renders correctly with all its parts', () => {
+    render(
+      <Select>
+        <Select.Label>Test Label</Select.Label>
+        <Select.Field data-testid="select-field">
+          <Select.Option value="option1">Option 1</Select.Option>
+          <Select.Option value="option2">Option 2</Select.Option>
+        </Select.Field>
+        <Select.HelperText>Helper text</Select.HelperText>
+      </Select>,
+    );
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+    expect(screen.getByTestId('select-field')).toBeInTheDocument();
+    expect(screen.getByText('Helper text')).toBeInTheDocument();
+  });
+
+  it('applies error state correctly', () => {
+    render(
+      <Select hasError>
+        <Select.Label>Error Label</Select.Label>
+        <Select.Field data-testid="select-field" />
+        <Select.HelperText data-testid="helper-text">
+          Error message
+        </Select.HelperText>
+      </Select>,
+    );
+
+    const selectField = screen.getByTestId('select-field');
+    const helperText = screen.getByTestId('helper-text');
+
+    expect(selectField).toHaveAttribute('data-error', 'true');
+    expect(helperText).toHaveAttribute('data-error', 'true');
+  });
+
+  it('has disabled state applied correctly', () => {
+    render(
+      <Select isDisabled>
+        <Select.Label>Disabled Label</Select.Label>
+        <Select.Field data-testid="select-field" />
+      </Select>,
+    );
+
+    const selectField = screen.getByTestId('select-field');
+    expect(selectField).toBeDisabled();
+  });
+
+  it('handles onChange correctly', () => {
+    const handleChange = vi.fn();
+
+    render(
+      <Select onChange={handleChange}>
+        <Select.Field data-testid="select-field">
+          <Select.Option value="option1">Option 1</Select.Option>
+          <Select.Option value="option2">Option 2</Select.Option>
+        </Select.Field>
+      </Select>,
+    );
+
+    const selectElement = screen.getByTestId('select-field');
+
+    // Change the select value
+    fireEvent.change(selectElement, { target: { value: 'option2' } });
+
+    expect(handleChange).toHaveBeenCalledWith('option2');
+  });
+
+  it('renders options correctly', () => {
+    render(
+      <Select>
+        <Select.Field data-testid="select-field">
+          <Select.Option value="option1">Option 1</Select.Option>
+          <Select.Option value="option2">Option 2</Select.Option>
+        </Select.Field>
+      </Select>,
+    );
+
+    // Get all options
+    const options = screen.getAllByRole('option');
+
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveTextContent('Option 1');
+    expect(options[1]).toHaveTextContent('Option 2');
+  });
+
+  it('renders with placeholder', () => {
+    render(
+      <Select>
+        <Select.Field placeholder="Select something" data-testid="select-field">
+          <Select.Option value="option1">Option 1</Select.Option>
+        </Select.Field>
+      </Select>,
+    );
+
+    const options = screen.getAllByRole('option');
+    expect(options[0]).toHaveTextContent('Select something');
+    expect(options[0]).toHaveAttribute('value', '');
+    expect(options[0]).toBeDisabled();
+  });
+
+  it('handles disabled options', () => {
+    render(
+      <Select>
+        <Select.Field data-testid="select-field">
+          <Select.Option value="option1">Option 1</Select.Option>
+          <Select.Option value="option2" disabled>
+            Option 2
+          </Select.Option>
+        </Select.Field>
+      </Select>,
+    );
+
+    const options = screen.getAllByRole('option');
+    expect(options[1]).toBeDisabled();
+  });
+
+  it('renders with lead element', () => {
+    render(
+      <Select>
+        <Select.Field data-testid="select-field">
+          <Select.LeadElement data-testid="lead-element">
+            Icon
+          </Select.LeadElement>
+          <Select.Option value="option1">Option 1</Select.Option>
+        </Select.Field>
+      </Select>,
+    );
+
+    expect(screen.getByTestId('lead-element')).toBeInTheDocument();
+    expect(screen.getByTestId('select-field')).toHaveAttribute(
+      'data-has-lead-element',
+      'true',
+    );
+  });
+
+  it('renders with trail element', () => {
+    render(
+      <Select>
+        <Select.Field data-testid="select-field">
+          <Select.TrailElement data-testid="trail-element">
+            Icon
+          </Select.TrailElement>
+          <Select.Option value="option1">Option 1</Select.Option>
+        </Select.Field>
+      </Select>,
+    );
+
+    expect(screen.getByTestId('trail-element')).toBeInTheDocument();
+  });
+});

--- a/packages/interfaces/ui-select/src/atoms/index.ts
+++ b/packages/interfaces/ui-select/src/atoms/index.ts
@@ -1,0 +1,8 @@
+/* eslint-disable import/max-dependencies */
+export { SelectContainer } from './select-container';
+export { SelectLabel } from './select-label';
+export { SelectField } from './select-field';
+export { SelectOption } from './select-option';
+export { SelectHelperText } from './select-helper-text';
+export { SelectLeadElement } from './select-lead-element';
+export { SelectTrailElement } from './select-trail-element';

--- a/packages/interfaces/ui-select/src/atoms/select-container.tsx
+++ b/packages/interfaces/ui-select/src/atoms/select-container.tsx
@@ -1,0 +1,45 @@
+import { forwardRef, ReactNode, HTMLAttributes } from 'react';
+
+import { ElSelectContainer } from './style';
+import { SelectProvider } from './use-select';
+
+export interface SelectContainerProps extends HTMLAttributes<HTMLDivElement> {
+  hasError?: boolean;
+  isDisabled?: boolean;
+  value?: string;
+  onValueChange?: (value: string) => void;
+  children: ReactNode;
+}
+
+export const SelectContainer = forwardRef<HTMLDivElement, SelectContainerProps>(
+  (
+    {
+      hasError = false,
+      isDisabled = false,
+      value,
+      onValueChange,
+      children,
+      ...rest
+    },
+    ref,
+  ) => {
+    const handleChange = (newValue: string) => {
+      if (onValueChange) {
+        onValueChange(newValue);
+      }
+    };
+
+    return (
+      <SelectProvider
+        hasError={hasError}
+        isDisabled={isDisabled}
+        value={value}
+        onValueChange={handleChange}
+      >
+        <ElSelectContainer ref={ref} {...rest}>
+          {children}
+        </ElSelectContainer>
+      </SelectProvider>
+    );
+  },
+);

--- a/packages/interfaces/ui-select/src/atoms/select-field.tsx
+++ b/packages/interfaces/ui-select/src/atoms/select-field.tsx
@@ -1,0 +1,52 @@
+import { forwardRef, SelectHTMLAttributes, ChangeEvent, useRef } from 'react';
+
+import { ElSelectWrapper, ElSelect } from './style';
+import { useSelect } from './use-select';
+
+export interface SelectFieldProps
+  extends SelectHTMLAttributes<HTMLSelectElement> {
+  placeholder?: string;
+}
+
+export const SelectField = forwardRef<HTMLSelectElement, SelectFieldProps>(
+  ({ placeholder, children, ...rest }, ref) => {
+    const {
+      hasError,
+      isDisabled,
+      hasLeadElement,
+      value,
+      selectId,
+      selectWrapperId,
+      onValueChange: contextOnChange,
+    } = useSelect();
+
+    const selectRef = useRef<HTMLSelectElement>(null);
+
+    const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
+      const newValue = e.target.value;
+      contextOnChange?.(newValue);
+    };
+
+    return (
+      <ElSelectWrapper id={selectWrapperId}>
+        <ElSelect
+          ref={ref || selectRef}
+          id={selectId}
+          onChange={handleChange}
+          disabled={isDisabled}
+          data-error={hasError}
+          data-has-lead-element={hasLeadElement}
+          value={value || undefined}
+          {...rest}
+        >
+          {placeholder && (
+            <option value="" disabled={value !== ''}>
+              {placeholder}
+            </option>
+          )}
+          {children}
+        </ElSelect>
+      </ElSelectWrapper>
+    );
+  },
+);

--- a/packages/interfaces/ui-select/src/atoms/select-helper-text.tsx
+++ b/packages/interfaces/ui-select/src/atoms/select-helper-text.tsx
@@ -1,0 +1,26 @@
+import { forwardRef, HTMLAttributes, ReactNode } from 'react';
+
+import { ElSelectHelperText } from './style';
+import { useSelect } from './use-select';
+
+export interface SelectHelperTextProps extends HTMLAttributes<HTMLSpanElement> {
+  children: ReactNode;
+}
+
+export const SelectHelperText = forwardRef<
+  HTMLSpanElement,
+  SelectHelperTextProps
+>(({ children, ...rest }, ref) => {
+  const { hasError, selectId } = useSelect();
+
+  return (
+    <ElSelectHelperText
+      ref={ref}
+      data-error={hasError}
+      id={`${selectId}-helper-text`}
+      {...rest}
+    >
+      {children}
+    </ElSelectHelperText>
+  );
+});

--- a/packages/interfaces/ui-select/src/atoms/select-label.tsx
+++ b/packages/interfaces/ui-select/src/atoms/select-label.tsx
@@ -1,0 +1,26 @@
+import { forwardRef, LabelHTMLAttributes, ReactNode } from 'react';
+
+import { ElSelectLabel } from './style';
+import { useSelect } from './use-select';
+
+export interface SelectLabelProps
+  extends LabelHTMLAttributes<HTMLLabelElement> {
+  children: ReactNode;
+}
+
+export const SelectLabel = forwardRef<HTMLLabelElement, SelectLabelProps>(
+  ({ children, ...rest }, ref) => {
+    const { selectId, isDisabled } = useSelect();
+
+    return (
+      <ElSelectLabel
+        ref={ref}
+        htmlFor={selectId}
+        {...rest}
+        aria-disabled={isDisabled}
+      >
+        {children}
+      </ElSelectLabel>
+    );
+  },
+);

--- a/packages/interfaces/ui-select/src/atoms/select-lead-element.tsx
+++ b/packages/interfaces/ui-select/src/atoms/select-lead-element.tsx
@@ -1,0 +1,34 @@
+import { forwardRef, HTMLAttributes, ReactNode, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+
+import { ElSelectLeadElement } from './style';
+import { useSelect } from './use-select';
+
+export interface SelectLeadElementProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export const SelectLeadElement = forwardRef<
+  HTMLDivElement,
+  SelectLeadElementProps
+>(({ children, ...rest }, ref) => {
+  const { registerLeadElement, selectWrapperId } = useSelect();
+
+  useEffect(() => {
+    registerLeadElement();
+  }, [registerLeadElement]);
+
+  const el = document.getElementById(selectWrapperId);
+  if (!el) return null;
+
+  return (
+    <>
+      {createPortal(
+        <ElSelectLeadElement ref={ref} {...rest}>
+          {children}
+        </ElSelectLeadElement>,
+        el,
+      )}
+    </>
+  );
+});

--- a/packages/interfaces/ui-select/src/atoms/select-option.tsx
+++ b/packages/interfaces/ui-select/src/atoms/select-option.tsx
@@ -1,0 +1,19 @@
+import { forwardRef, OptionHTMLAttributes, ReactNode } from 'react';
+
+import { ElSelectOption } from './style';
+
+export interface SelectOptionProps
+  extends OptionHTMLAttributes<HTMLOptionElement> {
+  value: string;
+  children: ReactNode;
+}
+
+export const SelectOption = forwardRef<HTMLOptionElement, SelectOptionProps>(
+  ({ value, children, disabled, ...rest }, ref) => {
+    return (
+      <ElSelectOption ref={ref} value={value} disabled={disabled} {...rest}>
+        {children}
+      </ElSelectOption>
+    );
+  },
+);

--- a/packages/interfaces/ui-select/src/atoms/select-trail-element.tsx
+++ b/packages/interfaces/ui-select/src/atoms/select-trail-element.tsx
@@ -1,0 +1,35 @@
+import { forwardRef, HTMLAttributes, ReactNode, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+
+import { ElSelectTrailElement } from './style';
+import { useSelect } from './use-select';
+
+export interface SelectTrailElementProps
+  extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode;
+}
+
+export const SelectTrailElement = forwardRef<
+  HTMLDivElement,
+  SelectTrailElementProps
+>(({ children, ...rest }, ref) => {
+  const { registerTrailElement, selectWrapperId } = useSelect();
+
+  useEffect(() => {
+    registerTrailElement();
+  }, [registerTrailElement]);
+
+  const el = document.getElementById(selectWrapperId);
+  if (!el) return null;
+
+  return (
+    <>
+      {createPortal(
+        <ElSelectTrailElement ref={ref} {...rest}>
+          {children}
+        </ElSelectTrailElement>,
+        el,
+      )}
+    </>
+  );
+});

--- a/packages/interfaces/ui-select/src/atoms/style.ts
+++ b/packages/interfaces/ui-select/src/atoms/style.ts
@@ -1,0 +1,115 @@
+import { styled } from '@linaria/react';
+
+const layout = `
+  display: flex;
+  flex-direction: column;
+`;
+
+export const ElSelectContainer = styled.div`
+  ${layout}
+  position: relative;
+  gap: var(--components-select-gap);
+  width: 100%;
+`;
+
+export const ElSelectLabel = styled.label`
+  font-size: var(--components-select-font-size-label);
+  line-height: var(--components-select-line-height-label);
+  font-weight: var(--components-select-font-weight-label);
+  color: var(--components-select-colors-label);
+`;
+
+export const ElSelectWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+export const ElSelect = styled.select`
+  width: 100%;
+  font-size: var(--components-select-font-size-input);
+  line-height: var(--components-select-line-height-input);
+  font-weight: var(--components-select-font-weight-input);
+  color: var(--components-select-colors-input-text);
+  background-color: var(--components-select-colors-background-rest);
+  border-radius: var(--components-select-border-radius);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--components-select-colors-background-outline);
+  appearance: none;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--components-select-colors-border-focus);
+    box-shadow: 0 0 0 4px
+      color-mix(
+        in srgb,
+        var(--components-select-colors-border-focus),
+        transparent 70%
+      );
+  }
+
+  &[data-error='true'] {
+    border-color: var(--components-select-colors-border-error);
+  }
+
+  &:disabled {
+    opacity: 0.32;
+    cursor: not-allowed;
+  }
+
+  &[data-has-lead-element='true'] {
+    padding-left: 32px;
+  }
+`;
+
+export const ElSelectOption = styled.option`
+  font-size: var(--components-select-font-size-option);
+  line-height: var(--components-select-line-height-option);
+  font-weight: var(--components-select-font-weight-option);
+  padding: var(--space-2);
+`;
+
+export const ElSelectHelperText = styled.span`
+  font-size: var(--components-select-font-size-helper);
+  line-height: var(--components-select-line-height-helper);
+  color: var(--components-select-colors-helper-text-normal);
+  padding: var(--space-none) var(--space-3);
+
+  &[data-error='true'] {
+    color: var(--components-select-colors-helper-text-error);
+  }
+`;
+
+export const ElSelectLeadElement = styled.div`
+  position: absolute;
+  left: 5px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+  pointer-events: none;
+`;
+
+export const ElSelectTrailElement = styled.div`
+  position: absolute;
+  right: 5px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+  pointer-events: none;
+
+  /* Default arrow icon */
+  &:empty::before {
+    content: '';
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 5px solid currentColor;
+  }
+`;

--- a/packages/interfaces/ui-select/src/atoms/use-select.tsx
+++ b/packages/interfaces/ui-select/src/atoms/use-select.tsx
@@ -1,0 +1,72 @@
+import { createContext, useContext, ReactNode, useState, useId } from 'react';
+
+interface SelectContextType {
+  hasLeadElement: boolean;
+  hasTrailElement: boolean;
+  hasError: boolean;
+  isDisabled: boolean;
+  selectId: string;
+  selectWrapperId: string;
+  registerLeadElement: () => void;
+  registerTrailElement: () => void;
+  value?: string;
+  onValueChange?: (value: string) => void;
+}
+
+const SelectContext = createContext<SelectContextType | undefined>(undefined);
+
+export const useSelect = () => {
+  const context = useContext(SelectContext);
+  if (!context) {
+    throw new Error('useSelect must be used within a SelectProvider');
+  }
+  return context;
+};
+
+interface SelectProviderProps {
+  children: ReactNode;
+  hasError?: boolean;
+  isDisabled?: boolean;
+  value?: string;
+  onValueChange?: (value: string) => void;
+}
+
+export const SelectProvider = ({
+  children,
+  hasError = false,
+  isDisabled = false,
+  value,
+  onValueChange,
+}: SelectProviderProps) => {
+  const [hasLeadElement, setHasLeadElement] = useState(false);
+  const [hasTrailElement, setHasTrailElement] = useState(false);
+  const selectId = useId();
+  const selectWrapperId = useId();
+
+  const registerLeadElement = () => {
+    setHasLeadElement(true);
+  };
+
+  const registerTrailElement = () => {
+    setHasTrailElement(true);
+  };
+
+  return (
+    <SelectContext.Provider
+      value={{
+        hasLeadElement,
+        hasTrailElement,
+        registerLeadElement,
+        registerTrailElement,
+        hasError,
+        isDisabled,
+        selectId,
+        selectWrapperId,
+        value,
+        onValueChange,
+      }}
+    >
+      {children}
+    </SelectContext.Provider>
+  );
+};

--- a/packages/interfaces/ui-select/src/index.ts
+++ b/packages/interfaces/ui-select/src/index.ts
@@ -1,0 +1,29 @@
+import {
+  SelectContainer,
+  SelectLabel,
+  SelectField,
+  SelectOption,
+  SelectHelperText,
+  SelectLeadElement,
+  SelectTrailElement,
+} from './atoms';
+
+type CompoundSelectProps = {
+  Label: typeof SelectLabel;
+  Field: typeof SelectField;
+  Option: typeof SelectOption;
+  HelperText: typeof SelectHelperText;
+  LeadElement: typeof SelectLeadElement;
+  TrailElement: typeof SelectTrailElement;
+};
+
+const CompoundSelect = {
+  Label: SelectLabel,
+  Field: SelectField,
+  Option: SelectOption,
+  HelperText: SelectHelperText,
+  LeadElement: SelectLeadElement,
+  TrailElement: SelectTrailElement,
+} satisfies CompoundSelectProps;
+
+export const Select = Object.assign(SelectContainer, CompoundSelect);

--- a/packages/interfaces/ui-select/src/story.tsx
+++ b/packages/interfaces/ui-select/src/story.tsx
@@ -1,0 +1,194 @@
+import { Icon } from '@react-beauty/ui-icon';
+import { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { Select } from './index';
+
+// Consistent layout wrapper for all stories
+const StoryLayout = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ minWidth: '300px' }}>{children}</div>
+);
+
+const meta: Meta<typeof Select> = {
+  title: 'Interfaces/Select',
+  component: Select,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Select>;
+
+// Basic Select
+export const Basic: Story = {
+  render: () => (
+    <StoryLayout>
+      <Select>
+        <Select.Label>Choose an option</Select.Label>
+        <Select.Field placeholder="Select an option">
+          <Select.Option value="option1">Option 1</Select.Option>
+          <Select.Option value="option2">Option 2</Select.Option>
+          <Select.Option value="option3">Option 3</Select.Option>
+        </Select.Field>
+      </Select>
+    </StoryLayout>
+  ),
+};
+
+// Controlled Select
+export const Controlled: Story = {
+  render: () => {
+    const [value, setValue] = useState('option1');
+
+    const handleChange = (newValue: string) => {
+      setValue(newValue);
+    };
+
+    return (
+      <StoryLayout>
+        <Select value={value} onValueChange={handleChange}>
+          <Select.Label>Controlled select</Select.Label>
+          <Select.Field>
+            <Select.Option value="option1">Option 1</Select.Option>
+            <Select.Option value="option2">Option 2</Select.Option>
+            <Select.Option value="option3">Option 3</Select.Option>
+          </Select.Field>
+          <Select.HelperText>Selected value: {value}</Select.HelperText>
+        </Select>
+      </StoryLayout>
+    );
+  },
+};
+
+// Select with Helper Text
+export const WithHelperText: Story = {
+  render: () => (
+    <StoryLayout>
+      <Select>
+        <Select.Label>Choose an option</Select.Label>
+        <Select.Field placeholder="Select an option">
+          <Select.Option value="option1">Option 1</Select.Option>
+          <Select.Option value="option2">Option 2</Select.Option>
+          <Select.Option value="option3">Option 3</Select.Option>
+        </Select.Field>
+        <Select.HelperText>
+          Please select one option from the list
+        </Select.HelperText>
+      </Select>
+    </StoryLayout>
+  ),
+};
+
+// Select with Error State
+export const WithError: Story = {
+  render: () => (
+    <StoryLayout>
+      <Select hasError>
+        <Select.Label>Choose an option</Select.Label>
+        <Select.Field placeholder="Select an option">
+          <Select.Option value="option1">Option 1</Select.Option>
+          <Select.Option value="option2">Option 2</Select.Option>
+          <Select.Option value="option3">Option 3</Select.Option>
+        </Select.Field>
+        <Select.HelperText>This field is required</Select.HelperText>
+      </Select>
+    </StoryLayout>
+  ),
+};
+
+// Disabled Select
+export const Disabled: Story = {
+  render: () => (
+    <StoryLayout>
+      <Select isDisabled>
+        <Select.Label>Choose an option</Select.Label>
+        <Select.Field placeholder="Select an option">
+          <Select.Option value="option1">Option 1</Select.Option>
+          <Select.Option value="option2">Option 2</Select.Option>
+          <Select.Option value="option3">Option 3</Select.Option>
+        </Select.Field>
+        <Select.HelperText>This field is disabled</Select.HelperText>
+      </Select>
+    </StoryLayout>
+  ),
+};
+
+// With Disabled Option
+export const WithDisabledOption: Story = {
+  render: () => (
+    <StoryLayout>
+      <Select>
+        <Select.Label>Choose an option</Select.Label>
+        <Select.Field placeholder="Select an option">
+          <Select.Option value="option1">Option 1</Select.Option>
+          <Select.Option value="option2" disabled>
+            Option 2 (Disabled)
+          </Select.Option>
+          <Select.Option value="option3">Option 3</Select.Option>
+        </Select.Field>
+      </Select>
+    </StoryLayout>
+  ),
+};
+
+// With Lead Element
+export const WithLeadElement: Story = {
+  render: () => (
+    <StoryLayout>
+      <Select>
+        <Select.LeadElement>
+          <Icon name="otherFrame" />
+        </Select.LeadElement>
+        <Select.Label>Choose an option</Select.Label>
+        <Select.Field placeholder="Select an option">
+          <Select.Option value="option1">Option 1</Select.Option>
+          <Select.Option value="option2">Option 2</Select.Option>
+          <Select.Option value="option3">Option 3</Select.Option>
+        </Select.Field>
+      </Select>
+    </StoryLayout>
+  ),
+};
+
+// With Trail Element
+export const WithTrailElement: Story = {
+  render: () => (
+    <StoryLayout>
+      <Select>
+        <Select.Label>Choose an option</Select.Label>
+        <Select.Field placeholder="Select an option">
+          <Select.Option value="option1">Option 1</Select.Option>
+          <Select.Option value="option2">Option 2</Select.Option>
+          <Select.Option value="option3">Option 3</Select.Option>
+        </Select.Field>
+        <Select.TrailElement>
+          <Icon name="controlsChevronDown" />
+        </Select.TrailElement>
+      </Select>
+    </StoryLayout>
+  ),
+};
+
+// With Both Lead and Trail Elements
+export const WithBothLeadAndTrailElements: Story = {
+  render: () => (
+    <StoryLayout>
+      <Select>
+        <Select.LeadElement>
+          <Icon name="otherFrame" />
+        </Select.LeadElement>
+        <Select.Label>Choose an option</Select.Label>
+        <Select.Field placeholder="Select an option">
+          <Select.Option value="option1">Option 1</Select.Option>
+          <Select.Option value="option2">Option 2</Select.Option>
+          <Select.Option value="option3">Option 3</Select.Option>
+        </Select.Field>
+        <Select.TrailElement>
+          <Icon name="controlsChevronDown" />
+        </Select.TrailElement>
+      </Select>
+    </StoryLayout>
+  ),
+};

--- a/packages/interfaces/ui-select/src/tokens/dark.json
+++ b/packages/interfaces/ui-select/src/tokens/dark.json
@@ -1,0 +1,113 @@
+{
+  "components": {
+    "select": {
+      "border-radius": {
+        "value": "{border-radius.xs}"
+      },
+      "font-size": {
+        "label": {
+          "value": "{font-size.sm}"
+        },
+        "input": {
+          "value": "{font-size.xs}"
+        },
+        "helper": {
+          "value": "{font-size.xs}"
+        },
+        "option": {
+          "value": "{font-size.xs}"
+        }
+      },
+      "line-height": {
+        "label": {
+          "value": "{font-line-height.sm}"
+        },
+        "input": {
+          "value": "{font-line-height.xs}"
+        },
+        "helper": {
+          "value": "{font-line-height.xs}"
+        },
+        "option": {
+          "value": "{font-line-height.xs}"
+        }
+      },
+      "font-weight": {
+        "label": {
+          "value": "{font-weight.medium}"
+        },
+        "input": {
+          "value": "{font-weight.regular}"
+        },
+        "option": {
+          "value": "{font-weight.regular}"
+        }
+      },
+      "padding": {
+        "input": {
+          "horizontal": {
+            "value": "{space.3}"
+          },
+          "vertical": {
+            "value": "{space.2}"
+          }
+        }
+      },
+      "gap": {
+        "value": "{space.1}"
+      },
+      "border-width": {
+        "value": "1px"
+      },
+      "colors": {
+        "label": {
+          "value": "{colors.main.bulma}"
+        },
+        "input-text": {
+          "value": "{colors.main.bulma}"
+        },
+        "placeholder": {
+          "value": "{colors.main.trunks}"
+        },
+        "border": {
+          "rest": {
+            "value": "{colors.main.trunks}"
+          },
+          "hover": {
+            "value": "{colors.main.picollo}"
+          },
+          "focus": {
+            "value": "{colors.main.picollo}"
+          },
+          "error": {
+            "value": "{colors.supportive.chichi}"
+          }
+        },
+        "background": {
+          "rest": {
+            "value": "{colors.main.gohan}"
+          },
+          "outline": {
+            "value": "{colors.main.trunks}"
+          },
+          "option": {
+            "hover": {
+              "value": "{colors.main.picollo}"
+            },
+            "selected": {
+              "value": "{colors.main.picollo}"
+            }
+          }
+        },
+        "helper-text": {
+          "normal": {
+            "value": "{colors.main.trunks}"
+          },
+          "error": {
+            "value": "{colors.supportive.chichi}"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/interfaces/ui-select/src/tokens/light.json
+++ b/packages/interfaces/ui-select/src/tokens/light.json
@@ -1,0 +1,113 @@
+{
+  "components": {
+    "select": {
+      "border-radius": {
+        "value": "{border-radius.xs}"
+      },
+      "font-size": {
+        "label": {
+          "value": "{font-size.sm}"
+        },
+        "input": {
+          "value": "{font-size.xs}"
+        },
+        "helper": {
+          "value": "{font-size.xs}"
+        },
+        "option": {
+          "value": "{font-size.xs}"
+        }
+      },
+      "line-height": {
+        "label": {
+          "value": "{font-line-height.sm}"
+        },
+        "input": {
+          "value": "{font-line-height.xs}"
+        },
+        "helper": {
+          "value": "{font-line-height.xs}"
+        },
+        "option": {
+          "value": "{font-line-height.xs}"
+        }
+      },
+      "font-weight": {
+        "label": {
+          "value": "{font-weight.medium}"
+        },
+        "input": {
+          "value": "{font-weight.regular}"
+        },
+        "option": {
+          "value": "{font-weight.regular}"
+        }
+      },
+      "padding": {
+        "input": {
+          "horizontal": {
+            "value": "{space.3}"
+          },
+          "vertical": {
+            "value": "{space.2}"
+          }
+        }
+      },
+      "gap": {
+        "value": "{space.1}"
+      },
+      "border-width": {
+        "value": "1px"
+      },
+      "colors": {
+        "label": {
+          "value": "{colors.main.bulma}"
+        },
+        "input-text": {
+          "value": "{colors.main.bulma}"
+        },
+        "placeholder": {
+          "value": "{colors.main.trunks}"
+        },
+        "border": {
+          "rest": {
+            "value": "{colors.main.trunks}"
+          },
+          "hover": {
+            "value": "{colors.main.picollo}"
+          },
+          "focus": {
+            "value": "{colors.main.picollo}"
+          },
+          "error": {
+            "value": "{colors.supportive.chichi}"
+          }
+        },
+        "background": {
+          "rest": {
+            "value": "{colors.main.gohan}"
+          },
+          "outline": {
+            "value": "{colors.main.trunks}"
+          },
+          "option": {
+            "hover": {
+              "value": "{colors.main.picollo}"
+            },
+            "selected": {
+              "value": "{colors.main.picollo}"
+            }
+          }
+        },
+        "helper-text": {
+          "normal": {
+            "value": "{colors.main.trunks}"
+          },
+          "error": {
+            "value": "{colors.supportive.chichi}"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/interfaces/ui-select/tsconfig.json
+++ b/packages/interfaces/ui-select/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@react-beauty/tsc/react",
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "__tests__"
+  ]
+}

--- a/packages/interfaces/ui-select/vite.config.ts
+++ b/packages/interfaces/ui-select/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig, viteConfig } from '@react-beauty/vite/package';
+
+import packageManifest from './package.json';
+
+export default defineConfig(viteConfig(packageManifest));

--- a/packages/interfaces/ui-select/vitest.config.ts
+++ b/packages/interfaces/ui-select/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig, vitestConfig } from '@react-beauty/vitest';
+
+import packageManifest from './package.json';
+
+const { name } = packageManifest ?? {};
+export default defineConfig(vitestConfig({ name }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1214,6 +1214,7 @@ __metadata:
     "@react-beauty/ui-menu-item": "workspace:*"
     "@react-beauty/ui-pagination": "workspace:*"
     "@react-beauty/ui-radio": "workspace:*"
+    "@react-beauty/ui-select": "workspace:*"
     "@react-beauty/ui-switch": "workspace:*"
     "@react-beauty/ui-tag": "workspace:*"
     "@react-beauty/ui-text-area": "workspace:*"
@@ -1456,6 +1457,23 @@ __metadata:
 "@react-beauty/ui-radio@workspace:*, @react-beauty/ui-radio@workspace:packages/interfaces/ui-radio":
   version: 0.0.0-use.local
   resolution: "@react-beauty/ui-radio@workspace:packages/interfaces/ui-radio"
+  dependencies:
+    "@linaria/core": "npm:6.3.0"
+    "@linaria/react": "npm:6.3.0"
+    "@react-beauty/eslint": "workspace:*"
+    "@react-beauty/storybook": "workspace:*"
+    "@react-beauty/tsc": "workspace:*"
+    "@react-beauty/vite": "workspace:*"
+    "@react-beauty/vitest": "workspace:*"
+  peerDependencies:
+    "@types/react": ^18.0
+    react: ^18.0
+  languageName: unknown
+  linkType: soft
+
+"@react-beauty/ui-select@workspace:*, @react-beauty/ui-select@workspace:packages/interfaces/ui-select":
+  version: 0.0.0-use.local
+  resolution: "@react-beauty/ui-select@workspace:packages/interfaces/ui-select"
   dependencies:
     "@linaria/core": "npm:6.3.0"
     "@linaria/react": "npm:6.3.0"


### PR DESCRIPTION
- Created Select component with Label, Field, Option, HelperText, LeadElement, and TrailElement.
- Implemented context for managing state and behavior of the Select component.
- Added tests for Select component functionality.
- Configured ESLint, TypeScript, Vite, and Vitest for the new package.
- Added dark and light theme tokens for styling.
- Updated package.json and yarn.lock to include new dependencies and configurations.