### PR TITLE
feat(ui-text): add new typography component with customizable styles and props

### DIFF
--- a/internal/storybook/.storybook/main.ts
+++ b/internal/storybook/.storybook/main.ts
@@ -37,6 +37,7 @@ const config: StorybookConfig = {
     getStoriesPath('interfaces/ui-bottom-sheet'),
     getStoriesPath('interfaces/ui-sidebar'),
     getStoriesPath('interfaces/ui-loader'),
+    getStoriesPath('interfaces/ui-text'),
   ],
   addons: [
     getAbsolutePath('@storybook/addon-essentials'),

--- a/packages/interfaces/module/package.json
+++ b/packages/interfaces/module/package.json
@@ -25,31 +25,6 @@
         "import": "./dist/index.js",
         "types": "./dist/index.d.ts"
       }
-    },
-    "dependencies": {
-      "@react-beauty/ui-accordion": "latest",
-      "@react-beauty/ui-alert": "latest",
-      "@react-beauty/ui-avatar": "latest",
-      "@react-beauty/ui-bottom-sheet": "latest",
-      "@react-beauty/ui-breadcrumb": "latest",
-      "@react-beauty/ui-button": "latest",
-      "@react-beauty/ui-checkbox": "latest",
-      "@react-beauty/ui-core": "latest",
-      "@react-beauty/ui-drawer": "latest",
-      "@react-beauty/ui-empty-state": "latest",
-      "@react-beauty/ui-icon": "latest",
-      "@react-beauty/ui-loader": "latest",
-      "@react-beauty/ui-menu-item": "latest",
-      "@react-beauty/ui-modal": "latest",
-      "@react-beauty/ui-pagination": "latest",
-      "@react-beauty/ui-radio": "latest",
-      "@react-beauty/ui-select": "latest",
-      "@react-beauty/ui-sidebar": "latest",
-      "@react-beauty/ui-switch": "latest",
-      "@react-beauty/ui-tag": "latest",
-      "@react-beauty/ui-text-area": "latest",
-      "@react-beauty/ui-text-input": "latest",
-      "@react-beauty/ui-tooltip": "latest"
     }
   },
   "scripts": {
@@ -78,6 +53,7 @@
     "@react-beauty/ui-sidebar": "workspace:*",
     "@react-beauty/ui-switch": "workspace:*",
     "@react-beauty/ui-tag": "workspace:*",
+    "@react-beauty/ui-text": "workspace:*",
     "@react-beauty/ui-text-area": "workspace:*",
     "@react-beauty/ui-text-input": "workspace:*",
     "@react-beauty/ui-tooltip": "workspace:*"

--- a/packages/interfaces/module/src/index.ts
+++ b/packages/interfaces/module/src/index.ts
@@ -22,3 +22,4 @@ export * from '@react-beauty/ui-modal';
 export * from '@react-beauty/ui-bottom-sheet';
 export * from '@react-beauty/ui-loader';
 export * from '@react-beauty/ui-sidebar';
+export * from '@react-beauty/ui-text';

--- a/packages/interfaces/ui-core/src/dark/index.css
+++ b/packages/interfaces/ui-core/src/dark/index.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Sat, 10 May 2025 18:41:27 GMT
+ * Generated on Mon, 12 May 2025 07:16:51 GMT
  */
 
 :root[data-theme='dark'] {
@@ -181,6 +181,13 @@
   --components-switch-transition-duration: 0.2s;
   --components-switch-transition-timing: ease-in-out;
   --components-text-input-border-width: 1px;
+  --components-text-margin-h1: 0 0 16px 0;
+  --components-text-margin-h2: 0 0 16px 0;
+  --components-text-margin-h3: 0 0 16px 0;
+  --components-text-margin-h4: 0 0 12px 0;
+  --components-text-margin-h5: 0 0 12px 0;
+  --components-text-margin-h6: 0 0 8px 0;
+  --components-text-margin-p: 0 0 16px 0;
   --components-tooltip-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
   --components-tooltip-pointer-size: 6px;
   --components-tooltip-max-width: 280px;
@@ -566,6 +573,38 @@
   --components-text-input-colors-background-disabled: var(--colors-supportive-krilin);
   --components-text-input-colors-helper-text-normal: var(--colors-main-trunks);
   --components-text-input-colors-helper-text-error: var(--colors-supportive-chichi);
+  --components-text-color: var(--colors-main-bulma);
+  --components-text-font-family: var(--font-primary);
+  --components-text-font-weight-h1: var(--font-weight-bold);
+  --components-text-font-weight-h2: var(--font-weight-bold);
+  --components-text-font-weight-h3: var(--font-weight-bold);
+  --components-text-font-weight-h4: var(--font-weight-medium);
+  --components-text-font-weight-h5: var(--font-weight-medium);
+  --components-text-font-weight-h6: var(--font-weight-medium);
+  --components-text-font-weight-p: var(--font-weight-regular);
+  --components-text-font-weight-span: var(--font-weight-regular);
+  --components-text-font-weight-label: var(--font-weight-medium);
+  --components-text-font-weight-small: var(--font-weight-regular);
+  --components-text-font-size-h1: var(--font-size-4xl);
+  --components-text-font-size-h2: var(--font-size-3xl);
+  --components-text-font-size-h3: var(--font-size-2xl);
+  --components-text-font-size-h4: var(--font-size-xl);
+  --components-text-font-size-h5: var(--font-size-lg);
+  --components-text-font-size-h6: var(--font-size-md);
+  --components-text-font-size-p: var(--font-size-md);
+  --components-text-font-size-span: var(--font-size-md);
+  --components-text-font-size-label: var(--font-size-sm);
+  --components-text-font-size-small: var(--font-size-xs);
+  --components-text-line-height-h1: var(--font-line-height-4xl);
+  --components-text-line-height-h2: var(--font-line-height-3xl);
+  --components-text-line-height-h3: var(--font-line-height-2xl);
+  --components-text-line-height-h4: var(--font-line-height-xl);
+  --components-text-line-height-h5: var(--font-line-height-lg);
+  --components-text-line-height-h6: var(--font-line-height-md);
+  --components-text-line-height-p: var(--font-line-height-md);
+  --components-text-line-height-span: var(--font-line-height-md);
+  --components-text-line-height-label: var(--font-line-height-sm);
+  --components-text-line-height-small: var(--font-line-height-xs);
   --components-tooltip-background-color: var(--colors-main-bulma);
   --components-tooltip-text-color: var(--colors-main-gohan);
   --components-tooltip-border-radius: var(--border-radius-sm);

--- a/packages/interfaces/ui-core/src/light/index.css
+++ b/packages/interfaces/ui-core/src/light/index.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly, this file was auto-generated.
- * Generated on Sat, 10 May 2025 18:41:27 GMT
+ * Generated on Mon, 12 May 2025 07:16:51 GMT
  */
 
 :root[data-theme='light'] {
@@ -182,6 +182,13 @@
   --components-switch-transition-duration: 0.2s;
   --components-switch-transition-timing: ease-in-out;
   --components-text-input-border-width: 1px;
+  --components-text-margin-h1: 0 0 16px 0;
+  --components-text-margin-h2: 0 0 16px 0;
+  --components-text-margin-h3: 0 0 16px 0;
+  --components-text-margin-h4: 0 0 12px 0;
+  --components-text-margin-h5: 0 0 12px 0;
+  --components-text-margin-h6: 0 0 8px 0;
+  --components-text-margin-p: 0 0 16px 0;
   --components-tooltip-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
   --components-tooltip-pointer-size: 6px;
   --components-tooltip-max-width: 280px;
@@ -567,6 +574,38 @@
   --components-text-input-colors-background-disabled: var(--colors-supportive-krilin);
   --components-text-input-colors-helper-text-normal: var(--colors-main-trunks);
   --components-text-input-colors-helper-text-error: var(--colors-supportive-chichi);
+  --components-text-color: var(--colors-main-bulma);
+  --components-text-font-family: var(--font-primary);
+  --components-text-font-weight-h1: var(--font-weight-bold);
+  --components-text-font-weight-h2: var(--font-weight-bold);
+  --components-text-font-weight-h3: var(--font-weight-bold);
+  --components-text-font-weight-h4: var(--font-weight-medium);
+  --components-text-font-weight-h5: var(--font-weight-medium);
+  --components-text-font-weight-h6: var(--font-weight-medium);
+  --components-text-font-weight-p: var(--font-weight-regular);
+  --components-text-font-weight-span: var(--font-weight-regular);
+  --components-text-font-weight-label: var(--font-weight-medium);
+  --components-text-font-weight-small: var(--font-weight-regular);
+  --components-text-font-size-h1: var(--font-size-4xl);
+  --components-text-font-size-h2: var(--font-size-3xl);
+  --components-text-font-size-h3: var(--font-size-2xl);
+  --components-text-font-size-h4: var(--font-size-xl);
+  --components-text-font-size-h5: var(--font-size-lg);
+  --components-text-font-size-h6: var(--font-size-md);
+  --components-text-font-size-p: var(--font-size-md);
+  --components-text-font-size-span: var(--font-size-md);
+  --components-text-font-size-label: var(--font-size-sm);
+  --components-text-font-size-small: var(--font-size-xs);
+  --components-text-line-height-h1: var(--font-line-height-4xl);
+  --components-text-line-height-h2: var(--font-line-height-3xl);
+  --components-text-line-height-h3: var(--font-line-height-2xl);
+  --components-text-line-height-h4: var(--font-line-height-xl);
+  --components-text-line-height-h5: var(--font-line-height-lg);
+  --components-text-line-height-h6: var(--font-line-height-md);
+  --components-text-line-height-p: var(--font-line-height-md);
+  --components-text-line-height-span: var(--font-line-height-md);
+  --components-text-line-height-label: var(--font-line-height-sm);
+  --components-text-line-height-small: var(--font-line-height-xs);
   --components-tooltip-background-color: var(--colors-main-bulma);
   --components-tooltip-text-color: var(--colors-main-gohan);
   --components-tooltip-border-radius: var(--border-radius-sm);

--- a/packages/interfaces/ui-core/src/provider.tsx
+++ b/packages/interfaces/ui-core/src/provider.tsx
@@ -30,6 +30,7 @@ export const globals = css`
     @import '../../ui-sidebar/dist/index.css';
     @import '../../ui-switch/dist/index.css';
     @import '../../ui-tag/dist/index.css';
+    @import '../../ui-text/dist/index.css';
     @import '../../ui-text-area/dist/index.css';
     @import '../../ui-text-input/dist/index.css';
     @import '../../ui-tooltip/dist/index.css';

--- a/packages/interfaces/ui-core/src/provider.tsx
+++ b/packages/interfaces/ui-core/src/provider.tsx
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
 import { css } from '@linaria/core';
 import { FC, ReactNode } from 'react';
 
@@ -5,35 +8,70 @@ import { ThemeContext } from './context';
 import { ReactBeautyUITheme } from './types';
 import { useSetupThemeEffect } from './use-setup-theme-effect';
 
+/**
+ * Checks if a CSS file exists at the specified package path using Node.js fs module
+ * and returns the path for import if it exists, or an empty string if not.
+ * This function is meant to be used during build time, not in the browser.
+ */
+const dynamicImport = (packagePath: string): string => {
+  try {
+    // Create resolved path relative to the current file
+    const resolvedPath = `../../${packagePath}/dist/index.css`;
+    // Get the absolute path
+    const absolutePath = path.resolve(__dirname, resolvedPath);
+
+    // Use fs.existsSync to check if the file exists
+    if (fs.existsSync(absolutePath)) {
+      return resolvedPath;
+    } else {
+      console.warn(`CSS file does not exist: ${absolutePath}`);
+      return '';
+    }
+  } catch (error) {
+    // If there's any error, return empty string
+    console.warn(`Failed to check CSS file existence: ${packagePath}`, error);
+    return '';
+  }
+};
+
+/**
+ * Helper function to create CSS import statements if the file exists
+ */
+const getImportStatement = (packagePath: string): string => {
+  const cssPath = dynamicImport(packagePath);
+  return cssPath ? `@import '${cssPath}';` : '';
+};
+
 export const globals = css`
   :global() {
     @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Mulish&display=swap');
 
     @import './dark/index.css';
     @import './light/index.css';
-    @import '../../ui-accordion/dist/index.css';
-    @import '../../ui-alert/dist/index.css';
-    @import '../../ui-avatar/dist/index.css';
-    @import '../../ui-bottom-sheet/dist/index.css';
-    @import '../../ui-breadcrumb/dist/index.css';
-    @import '../../ui-button/dist/index.css';
-    @import '../../ui-checkbox/dist/index.css';
-    @import '../../ui-drawer/dist/index.css';
-    @import '../../ui-empty-state/dist/index.css';
-    @import '../../ui-icon/dist/index.css';
-    @import '../../ui-loader/dist/index.css';
-    @import '../../ui-menu-item/dist/index.css';
-    @import '../../ui-modal/dist/index.css';
-    @import '../../ui-pagination/dist/index.css';
-    @import '../../ui-radio/dist/index.css';
-    @import '../../ui-select/dist/index.css';
-    @import '../../ui-sidebar/dist/index.css';
-    @import '../../ui-switch/dist/index.css';
-    @import '../../ui-tag/dist/index.css';
-    @import '../../ui-text/dist/index.css';
-    @import '../../ui-text-area/dist/index.css';
-    @import '../../ui-text-input/dist/index.css';
-    @import '../../ui-tooltip/dist/index.css';
+
+    ${getImportStatement('ui-accordion')}
+    ${getImportStatement('ui-alert')}
+    ${getImportStatement('ui-avatar')}
+    ${getImportStatement('ui-bottom-sheet')}
+    ${getImportStatement('ui-breadcrumb')}
+    ${getImportStatement('ui-button')}
+    ${getImportStatement('ui-checkbox')}
+    ${getImportStatement('ui-drawer')}
+    ${getImportStatement('ui-empty-state')}
+    ${getImportStatement('ui-icon')}
+    ${getImportStatement('ui-loader')}
+    ${getImportStatement('ui-menu-item')}
+    ${getImportStatement('ui-modal')}
+    ${getImportStatement('ui-pagination')}
+    ${getImportStatement('ui-radio')}
+    ${getImportStatement('ui-select')}
+    ${getImportStatement('ui-sidebar')}
+    ${getImportStatement('ui-switch')}
+    ${getImportStatement('ui-tag')}
+    ${getImportStatement('ui-text')}
+    ${getImportStatement('ui-text-area')}
+    ${getImportStatement('ui-text-input')}
+    ${getImportStatement('ui-tooltip')}
 
     :root {
       box-sizing: border-box;

--- a/packages/interfaces/ui-text/README.md
+++ b/packages/interfaces/ui-text/README.md
@@ -1,0 +1,106 @@
+# @react-beauty/ui-text
+
+A versatile typography component that provides consistent text styling across your application.
+
+## Installation
+
+```bash
+npm install @react-beauty/ui-text
+```
+
+Or with yarn:
+
+```bash
+yarn add @react-beauty/ui-text
+```
+
+## Features
+
+- Supports various text elements (h1-h6, p, span, label, small)
+- Consistent styling with design tokens
+- Fully accessible
+- Customizable with additional props
+
+## Usage
+
+```jsx
+import { Text } from '@react-beauty/ui-text';
+
+function MyComponent() {
+  return (
+    <div>
+      <Text as="h1">Heading 1</Text>
+      <Text as="p">This is a paragraph of text.</Text>
+      <Text as="span">This is inline span text.</Text>
+      <Text as="small">Small print text</Text>
+    </div>
+  );
+}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| as | 'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6' \| 'p' \| 'span' \| 'label' \| 'small' | 'p' | The HTML element to render |
+| children | ReactNode | - | The content to display |
+| ...HTMLAttributes | - | - | All other props are passed to the underlying HTML element |
+
+## Examples
+
+### Headers
+
+```jsx
+<Text as="h1">Heading 1</Text>
+<Text as="h2">Heading 2</Text>
+<Text as="h3">Heading 3</Text>
+<Text as="h4">Heading 4</Text>
+<Text as="h5">Heading 5</Text>
+<Text as="h6">Heading 6</Text>
+```
+
+### Paragraph Text
+
+```jsx
+<Text as="p">
+  This is a paragraph with standard text. Lorem ipsum dolor sit amet, 
+  consectetur adipiscing elit. Integer nec odio. Praesent libero.
+</Text>
+```
+
+### Inline Text
+
+```jsx
+<div>
+  <Text as="span">This is span text. </Text>
+  <Text as="span">Another span right next to it.</Text>
+</div>
+```
+
+### Custom Styling
+
+You can apply additional styling to the Text component:
+
+```jsx
+<Text as="h1" style={{ color: 'var(--colors-main-picollo)' }}>
+  Custom Colored Heading
+</Text>
+
+<Text as="p" style={{ fontStyle: 'italic' }}>
+  This paragraph has custom italic styling.
+</Text>
+```
+
+### Using with data-testid
+
+For testing purposes, you can add a data-testid attribute:
+
+```jsx
+<Text data-testid="header-text" as="h1">
+  Testable Header
+</Text>
+```
+
+## License
+
+MIT

--- a/packages/interfaces/ui-text/eslint.config.js
+++ b/packages/interfaces/ui-text/eslint.config.js
@@ -1,0 +1,3 @@
+import { configs } from "@react-beauty/eslint";
+
+export default configs;

--- a/packages/interfaces/ui-text/package.json
+++ b/packages/interfaces/ui-text/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@react-beauty/ui-text",
+  "description": "ui-text",
+  "license": "MIT",
+  "version": "1.0.0",
+  "keywords": [
+    "react",
+    "@react-beauty",
+    "ui-text"
+  ],
+  "author": "Dimas Bagus P <dimas.bagus.pm1@gmail.com>",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": "./dist/index.js",
+        "types": "./dist/index.d.ts"
+      },
+      "./style.css": "./dist/style.css"
+    },
+    "dependencies": {
+      "@react-beauty/ui-core": "latest"
+    }
+  },
+  "scripts": {
+    "lint": "eslint src",
+    "check": "tsc --noEmit",
+    "build": "vite build --configLoader runner",
+    "test": "vitest run --configLoader runner"
+  },
+  "dependencies": {
+    "@react-beauty/ui-core": "workspace:*"
+  },
+  "peerDependencies": {
+    "@types/react": "^18.0",
+    "react": "^18.0"
+  },
+  "devDependencies": {
+    "@react-beauty/eslint": "workspace:*",
+    "@react-beauty/storybook": "workspace:*",
+    "@react-beauty/tsc": "workspace:*",
+    "@react-beauty/vite": "workspace:*",
+    "@react-beauty/vitest": "workspace:*"
+  }
+}

--- a/packages/interfaces/ui-text/src/__tests__/text.test.tsx
+++ b/packages/interfaces/ui-text/src/__tests__/text.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@react-beauty/vitest/selector';
+
+import { Text } from '..';
+
+describe('Text', () => {
+  it('renders correctly as p tag by default', () => {
+    render(<Text>Default text</Text>);
+    expect(screen.getByText('Default text')).toBeInTheDocument();
+    expect(screen.getByText('Default text').getAttribute('data-element')).toBe(
+      'p',
+    );
+  });
+
+  it('renders with custom data-testid', () => {
+    render(<Text data-testid="custom-text">Custom test id</Text>);
+    expect(screen.getByTestId('custom-text')).toBeInTheDocument();
+  });
+
+  it('applies h1 styles when as="h1"', () => {
+    render(<Text as="h1">Heading 1</Text>);
+    expect(screen.getByText('Heading 1').getAttribute('data-element')).toBe(
+      'h1',
+    );
+  });
+
+  it('applies h2 styles when as="h2"', () => {
+    render(<Text as="h2">Heading 2</Text>);
+    expect(screen.getByText('Heading 2').getAttribute('data-element')).toBe(
+      'h2',
+    );
+  });
+
+  it('applies h3 styles when as="h3"', () => {
+    render(<Text as="h3">Heading 3</Text>);
+    expect(screen.getByText('Heading 3').getAttribute('data-element')).toBe(
+      'h3',
+    );
+  });
+
+  it('applies h4 styles when as="h4"', () => {
+    render(<Text as="h4">Heading 4</Text>);
+    expect(screen.getByText('Heading 4').getAttribute('data-element')).toBe(
+      'h4',
+    );
+  });
+
+  it('applies h5 styles when as="h5"', () => {
+    render(<Text as="h5">Heading 5</Text>);
+    expect(screen.getByText('Heading 5').getAttribute('data-element')).toBe(
+      'h5',
+    );
+  });
+
+  it('applies h6 styles when as="h6"', () => {
+    render(<Text as="h6">Heading 6</Text>);
+    expect(screen.getByText('Heading 6').getAttribute('data-element')).toBe(
+      'h6',
+    );
+  });
+
+  it('applies span styles when as="span"', () => {
+    render(<Text as="span">Span text</Text>);
+    expect(screen.getByText('Span text').getAttribute('data-element')).toBe(
+      'span',
+    );
+  });
+
+  it('applies label styles when as="label"', () => {
+    render(<Text as="label">Label text</Text>);
+    expect(screen.getByText('Label text').getAttribute('data-element')).toBe(
+      'label',
+    );
+  });
+
+  it('applies small styles when as="small"', () => {
+    render(<Text as="small">Small text</Text>);
+    expect(screen.getByText('Small text').getAttribute('data-element')).toBe(
+      'small',
+    );
+  });
+
+  it('passes additional props correctly', () => {
+    render(
+      <Text className="custom-class" title="tooltip">
+        Additional props
+      </Text>,
+    );
+    const textElement = screen.getByText('Additional props');
+    expect(textElement).toHaveClass('custom-class');
+    expect(textElement).toHaveAttribute('title', 'tooltip');
+  });
+});

--- a/packages/interfaces/ui-text/src/atoms/index.ts
+++ b/packages/interfaces/ui-text/src/atoms/index.ts
@@ -1,0 +1,2 @@
+export * from './text';
+export * from './style';

--- a/packages/interfaces/ui-text/src/atoms/style.ts
+++ b/packages/interfaces/ui-text/src/atoms/style.ts
@@ -1,0 +1,93 @@
+import { styled } from '@linaria/react';
+
+type TextElement =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'p'
+  | 'span'
+  | 'label'
+  | 'small';
+
+interface TextProps {
+  as?: TextElement;
+}
+
+export const ElText = styled.div<TextProps>`
+  font-family: var(--components-text-font-family);
+  color: var(--components-text-color);
+  margin: 0;
+
+  &[data-element='h1'] {
+    font-size: var(--components-text-font-size-h1);
+    line-height: var(--components-text-line-height-h1);
+    font-weight: var(--components-text-font-weight-h1);
+    margin: var(--components-text-margin-h1);
+  }
+
+  &[data-element='h2'] {
+    font-size: var(--components-text-font-size-h2);
+    line-height: var(--components-text-line-height-h2);
+    font-weight: var(--components-text-font-weight-h2);
+    margin: var(--components-text-margin-h2);
+  }
+
+  &[data-element='h3'] {
+    font-size: var(--components-text-font-size-h3);
+    line-height: var(--components-text-line-height-h3);
+    font-weight: var(--components-text-font-weight-h3);
+    margin: var(--components-text-margin-h3);
+  }
+
+  &[data-element='h4'] {
+    font-size: var(--components-text-font-size-h4);
+    line-height: var(--components-text-line-height-h4);
+    font-weight: var(--components-text-font-weight-h4);
+    margin: var(--components-text-margin-h4);
+  }
+
+  &[data-element='h5'] {
+    font-size: var(--components-text-font-size-h5);
+    line-height: var(--components-text-line-height-h5);
+    font-weight: var(--components-text-font-weight-h5);
+    margin: var(--components-text-margin-h5);
+  }
+
+  &[data-element='h6'] {
+    font-size: var(--components-text-font-size-h6);
+    line-height: var(--components-text-line-height-h6);
+    font-weight: var(--components-text-font-weight-h6);
+    margin: var(--components-text-margin-h6);
+  }
+
+  &[data-element='p'] {
+    font-size: var(--components-text-font-size-p);
+    line-height: var(--components-text-line-height-p);
+    font-weight: var(--components-text-font-weight-p);
+    margin: var(--components-text-margin-p);
+  }
+
+  &[data-element='span'] {
+    font-size: var(--components-text-font-size-span);
+    line-height: var(--components-text-line-height-span);
+    font-weight: var(--components-text-font-weight-span);
+    display: inline;
+  }
+
+  &[data-element='label'] {
+    font-size: var(--components-text-font-size-label);
+    line-height: var(--components-text-line-height-label);
+    font-weight: var(--components-text-font-weight-label);
+    display: inline-block;
+  }
+
+  &[data-element='small'] {
+    font-size: var(--components-text-font-size-small);
+    line-height: var(--components-text-line-height-small);
+    font-weight: var(--components-text-font-weight-small);
+    display: inline-block;
+  }
+`;

--- a/packages/interfaces/ui-text/src/atoms/text.tsx
+++ b/packages/interfaces/ui-text/src/atoms/text.tsx
@@ -30,5 +30,3 @@ export const Text = forwardRef<HTMLDivElement, TextProps>(
 );
 
 Text.displayName = 'Text';
-
-Text.displayName = 'Text';

--- a/packages/interfaces/ui-text/src/atoms/text.tsx
+++ b/packages/interfaces/ui-text/src/atoms/text.tsx
@@ -1,0 +1,34 @@
+import { forwardRef, HTMLAttributes, ReactNode } from 'react';
+
+import { ElText } from './style';
+
+export type TextElement =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'p'
+  | 'span'
+  | 'label'
+  | 'small';
+
+export type TextProps = HTMLAttributes<HTMLDivElement> & {
+  as?: TextElement;
+  children: ReactNode;
+};
+
+export const Text = forwardRef<HTMLDivElement, TextProps>(
+  ({ as = 'p', children, ...props }, ref) => {
+    return (
+      <ElText ref={ref} data-element={as} {...props}>
+        {children}
+      </ElText>
+    );
+  },
+);
+
+Text.displayName = 'Text';
+
+Text.displayName = 'Text';

--- a/packages/interfaces/ui-text/src/index.ts
+++ b/packages/interfaces/ui-text/src/index.ts
@@ -1,0 +1,3 @@
+import { Text } from './atoms';
+
+export { Text };

--- a/packages/interfaces/ui-text/src/story.tsx
+++ b/packages/interfaces/ui-text/src/story.tsx
@@ -1,0 +1,176 @@
+import { Text } from '.';
+
+import type { Meta, StoryObj } from '@react-beauty/storybook';
+
+const meta = {
+  title: 'Text',
+  component: Text,
+  tags: ['autodocs'],
+  argTypes: {
+    as: {
+      control: 'select',
+      options: [
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'p',
+        'span',
+        'label',
+        'small',
+      ],
+      defaultValue: 'p',
+    },
+    children: {
+      control: 'text',
+    },
+  },
+  args: {
+    children: 'Text Component',
+  },
+} satisfies Meta<typeof Text>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'Default Text Component',
+  },
+};
+
+export const Heading1: Story = {
+  args: {
+    as: 'h1',
+    children: 'Heading 1',
+  },
+};
+
+export const Heading2: Story = {
+  args: {
+    as: 'h2',
+    children: 'Heading 2',
+  },
+};
+
+export const Heading3: Story = {
+  args: {
+    as: 'h3',
+    children: 'Heading 3',
+  },
+};
+
+export const Heading4: Story = {
+  args: {
+    as: 'h4',
+    children: 'Heading 4',
+  },
+};
+
+export const Heading5: Story = {
+  args: {
+    as: 'h5',
+    children: 'Heading 5',
+  },
+};
+
+export const Heading6: Story = {
+  args: {
+    as: 'h6',
+    children: 'Heading 6',
+  },
+};
+
+export const Paragraph: Story = {
+  args: {
+    as: 'p',
+    children:
+      'This is a paragraph of text. It demonstrates the paragraph styling with a bit more content to show how the text wraps and flows within the designated space.',
+  },
+};
+
+export const Span: Story = {
+  args: {
+    as: 'span',
+    children: 'This is inline span text.',
+  },
+  render: (args) => (
+    <div>
+      <Text>This is a paragraph with a </Text>
+      <Text {...args} />
+      <Text> inside it.</Text>
+    </div>
+  ),
+};
+
+export const Label: Story = {
+  args: {
+    as: 'label',
+    children: 'Form Label',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    as: 'small',
+    children: 'This is small text often used for captions or fine print.',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <Text as="h1">Heading 1</Text>
+      <Text as="h2">Heading 2</Text>
+      <Text as="h3">Heading 3</Text>
+      <Text as="h4">Heading 4</Text>
+      <Text as="h5">Heading 5</Text>
+      <Text as="h6">Heading 6</Text>
+      <Text as="p">
+        This is a paragraph with standard text. Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed
+        cursus ante dapibus diam.
+      </Text>
+      <div>
+        <Text as="span">This is span text. </Text>
+        <Text as="span">Another span right next to it.</Text>
+      </div>
+      <Text as="label">This is a label</Text>
+      <Text as="small">This is small text for fine details</Text>
+    </div>
+  ),
+};
+
+export const WithCustomStyling: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <Text as="h1" style={{ color: 'var(--colors-main-picollo)' }}>
+        Custom Colored Heading
+      </Text>
+      <Text as="p" style={{ fontStyle: 'italic' }}>
+        This paragraph has custom italic styling.
+      </Text>
+      <Text as="p" style={{ textDecoration: 'underline' }}>
+        This paragraph has an underline.
+      </Text>
+      <Text
+        as="span"
+        style={{
+          backgroundColor: 'var(--colors-main-beerus)',
+          padding: '4px 8px',
+          borderRadius: '4px',
+        }}
+      >
+        Span with background
+      </Text>
+    </div>
+  ),
+};
+
+export const WithDataTestId: Story = {
+  render: () => (
+    <Text data-testid="test-text">Text with data-testid for testing</Text>
+  ),
+};

--- a/packages/interfaces/ui-text/src/tokens/dark.json
+++ b/packages/interfaces/ui-text/src/tokens/dark.json
@@ -1,0 +1,131 @@
+{
+  "components": {
+    "text": {
+      "color": {
+        "value": "{colors.main.bulma}"
+      },
+      "font-family": {
+        "value": "{font-primary}"
+      },
+      "font-weight": {
+        "h1": {
+          "value": "{font-weight.bold}"
+        },
+        "h2": {
+          "value": "{font-weight.bold}"
+        },
+        "h3": {
+          "value": "{font-weight.bold}"
+        },
+        "h4": {
+          "value": "{font-weight.medium}"
+        },
+        "h5": {
+          "value": "{font-weight.medium}"
+        },
+        "h6": {
+          "value": "{font-weight.medium}"
+        },
+        "p": {
+          "value": "{font-weight.regular}"
+        },
+        "span": {
+          "value": "{font-weight.regular}"
+        },
+        "label": {
+          "value": "{font-weight.medium}"
+        },
+        "small": {
+          "value": "{font-weight.regular}"
+        }
+      },
+      "font-size": {
+        "h1": {
+          "value": "{font-size.4xl}"
+        },
+        "h2": {
+          "value": "{font-size.3xl}"
+        },
+        "h3": {
+          "value": "{font-size.2xl}"
+        },
+        "h4": {
+          "value": "{font-size.xl}"
+        },
+        "h5": {
+          "value": "{font-size.lg}"
+        },
+        "h6": {
+          "value": "{font-size.md}"
+        },
+        "p": {
+          "value": "{font-size.md}"
+        },
+        "span": {
+          "value": "{font-size.md}"
+        },
+        "label": {
+          "value": "{font-size.sm}"
+        },
+        "small": {
+          "value": "{font-size.xs}"
+        }
+      },
+      "line-height": {
+        "h1": {
+          "value": "{font-line-height.4xl}"
+        },
+        "h2": {
+          "value": "{font-line-height.3xl}"
+        },
+        "h3": {
+          "value": "{font-line-height.2xl}"
+        },
+        "h4": {
+          "value": "{font-line-height.xl}"
+        },
+        "h5": {
+          "value": "{font-line-height.lg}"
+        },
+        "h6": {
+          "value": "{font-line-height.md}"
+        },
+        "p": {
+          "value": "{font-line-height.md}"
+        },
+        "span": {
+          "value": "{font-line-height.md}"
+        },
+        "label": {
+          "value": "{font-line-height.sm}"
+        },
+        "small": {
+          "value": "{font-line-height.xs}"
+        }
+      },
+      "margin": {
+        "h1": {
+          "value": "0 0 16px 0"
+        },
+        "h2": {
+          "value": "0 0 16px 0"
+        },
+        "h3": {
+          "value": "0 0 16px 0"
+        },
+        "h4": {
+          "value": "0 0 12px 0"
+        },
+        "h5": {
+          "value": "0 0 12px 0"
+        },
+        "h6": {
+          "value": "0 0 8px 0"
+        },
+        "p": {
+          "value": "0 0 16px 0"
+        }
+      }
+    }
+  }
+}

--- a/packages/interfaces/ui-text/src/tokens/light.json
+++ b/packages/interfaces/ui-text/src/tokens/light.json
@@ -1,0 +1,131 @@
+{
+  "components": {
+    "text": {
+      "color": {
+        "value": "{colors.main.bulma}"
+      },
+      "font-family": {
+        "value": "{font-primary}"
+      },
+      "font-weight": {
+        "h1": {
+          "value": "{font-weight.bold}"
+        },
+        "h2": {
+          "value": "{font-weight.bold}"
+        },
+        "h3": {
+          "value": "{font-weight.bold}"
+        },
+        "h4": {
+          "value": "{font-weight.medium}"
+        },
+        "h5": {
+          "value": "{font-weight.medium}"
+        },
+        "h6": {
+          "value": "{font-weight.medium}"
+        },
+        "p": {
+          "value": "{font-weight.regular}"
+        },
+        "span": {
+          "value": "{font-weight.regular}"
+        },
+        "label": {
+          "value": "{font-weight.medium}"
+        },
+        "small": {
+          "value": "{font-weight.regular}"
+        }
+      },
+      "font-size": {
+        "h1": {
+          "value": "{font-size.4xl}"
+        },
+        "h2": {
+          "value": "{font-size.3xl}"
+        },
+        "h3": {
+          "value": "{font-size.2xl}"
+        },
+        "h4": {
+          "value": "{font-size.xl}"
+        },
+        "h5": {
+          "value": "{font-size.lg}"
+        },
+        "h6": {
+          "value": "{font-size.md}"
+        },
+        "p": {
+          "value": "{font-size.md}"
+        },
+        "span": {
+          "value": "{font-size.md}"
+        },
+        "label": {
+          "value": "{font-size.sm}"
+        },
+        "small": {
+          "value": "{font-size.xs}"
+        }
+      },
+      "line-height": {
+        "h1": {
+          "value": "{font-line-height.4xl}"
+        },
+        "h2": {
+          "value": "{font-line-height.3xl}"
+        },
+        "h3": {
+          "value": "{font-line-height.2xl}"
+        },
+        "h4": {
+          "value": "{font-line-height.xl}"
+        },
+        "h5": {
+          "value": "{font-line-height.lg}"
+        },
+        "h6": {
+          "value": "{font-line-height.md}"
+        },
+        "p": {
+          "value": "{font-line-height.md}"
+        },
+        "span": {
+          "value": "{font-line-height.md}"
+        },
+        "label": {
+          "value": "{font-line-height.sm}"
+        },
+        "small": {
+          "value": "{font-line-height.xs}"
+        }
+      },
+      "margin": {
+        "h1": {
+          "value": "0 0 16px 0"
+        },
+        "h2": {
+          "value": "0 0 16px 0"
+        },
+        "h3": {
+          "value": "0 0 16px 0"
+        },
+        "h4": {
+          "value": "0 0 12px 0"
+        },
+        "h5": {
+          "value": "0 0 12px 0"
+        },
+        "h6": {
+          "value": "0 0 8px 0"
+        },
+        "p": {
+          "value": "0 0 16px 0"
+        }
+      }
+    }
+  }
+}

--- a/packages/interfaces/ui-text/tsconfig.json
+++ b/packages/interfaces/ui-text/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@react-beauty/tsc/react",
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "__tests__"
+  ]
+}

--- a/packages/interfaces/ui-text/vite.config.ts
+++ b/packages/interfaces/ui-text/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig, viteConfig } from '@react-beauty/vite/package';
+
+import packageManifest from './package.json';
+
+export default defineConfig(viteConfig(packageManifest));

--- a/packages/interfaces/ui-text/vitest.config.ts
+++ b/packages/interfaces/ui-text/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig, vitestConfig } from '@react-beauty/vitest';
+
+import packageManifest from './package.json';
+
+export default defineConfig(vitestConfig(packageManifest));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1245,6 +1245,7 @@ __metadata:
     "@react-beauty/ui-sidebar": "workspace:*"
     "@react-beauty/ui-switch": "workspace:*"
     "@react-beauty/ui-tag": "workspace:*"
+    "@react-beauty/ui-text": "workspace:*"
     "@react-beauty/ui-text-area": "workspace:*"
     "@react-beauty/ui-text-input": "workspace:*"
     "@react-beauty/ui-tooltip": "workspace:*"
@@ -1641,6 +1642,22 @@ __metadata:
 "@react-beauty/ui-text-input@workspace:*, @react-beauty/ui-text-input@workspace:packages/interfaces/ui-text-input":
   version: 0.0.0-use.local
   resolution: "@react-beauty/ui-text-input@workspace:packages/interfaces/ui-text-input"
+  dependencies:
+    "@react-beauty/eslint": "workspace:*"
+    "@react-beauty/storybook": "workspace:*"
+    "@react-beauty/tsc": "workspace:*"
+    "@react-beauty/ui-core": "workspace:*"
+    "@react-beauty/vite": "workspace:*"
+    "@react-beauty/vitest": "workspace:*"
+  peerDependencies:
+    "@types/react": ^18.0
+    react: ^18.0
+  languageName: unknown
+  linkType: soft
+
+"@react-beauty/ui-text@workspace:*, @react-beauty/ui-text@workspace:packages/interfaces/ui-text":
+  version: 0.0.0-use.local
+  resolution: "@react-beauty/ui-text@workspace:packages/interfaces/ui-text"
   dependencies:
     "@react-beauty/eslint": "workspace:*"
     "@react-beauty/storybook": "workspace:*"


### PR DESCRIPTION
- Created @react-beauty/ui-text package for versatile text styling.
- Implemented Text component supporting various HTML elements (h1-h6, p, span, label, small).
- Added styling tokens for dark and light themes.
- Integrated with Storybook for documentation and examples.
- Updated package.json and added necessary scripts for linting, building, and testing.
- Created tests for Text component to ensure correct rendering and functionality.